### PR TITLE
Feat/web search

### DIFF
--- a/custom_components/mistral_conversation/__init__.py
+++ b/custom_components/mistral_conversation/__init__.py
@@ -30,6 +30,8 @@ class MistralRuntimeData:
     # Cached entity-context string; invalidated by state listener
     entity_context: str | None = field(default=None)
     entity_context_unsub: object | None = field(default=None)
+    # Cached Mistral Agent ID for web-search conversations
+    web_search_agent_id: str | None = field(default=None)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/mistral_conversation/__init__.py
+++ b/custom_components/mistral_conversation/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
@@ -20,10 +21,26 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = ["conversation", "stt"]
 
 
+@dataclass
+class MistralRuntimeData:
+    """Shared runtime data for a config entry."""
+
+    session: aiohttp.ClientSession
+    headers: dict[str, str]
+    # Cached entity-context string; invalidated by state listener
+    entity_context: str | None = field(default=None)
+    entity_context_unsub: object | None = field(default=None)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Mistral AI Conversation from a config entry."""
     api_key = entry.data[CONF_API_KEY]
     session = async_get_clientsession(hass)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
     try:
         async with session.get(
             f"{MISTRAL_API_BASE}/models",
@@ -37,6 +54,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady(f"Cannot connect to Mistral AI: {err}") from err
 
+    runtime = MistralRuntimeData(session=session, headers=headers)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
@@ -44,6 +64,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    runtime: MistralRuntimeData | None = hass.data.get(DOMAIN, {}).pop(
+        entry.entry_id, None
+    )
+    if runtime and runtime.entity_context_unsub:
+        runtime.entity_context_unsub()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/custom_components/mistral_conversation/config_flow.py
+++ b/custom_components/mistral_conversation/config_flow.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_PROMPT,
     CONF_STT_LANGUAGE,
     CONF_TEMPERATURE,
+    CONF_WEB_SEARCH,
     DEFAULT_CONTINUE_CONVERSATION,
     DEFAULT_CONTROL_HA,
     DEFAULT_MAX_TOKENS,
@@ -28,6 +29,7 @@ from .const import (
     DEFAULT_PROMPT,
     DEFAULT_STT_LANGUAGE,
     DEFAULT_TEMPERATURE,
+    DEFAULT_WEB_SEARCH,
     DOMAIN,
     MISTRAL_API_BASE,
 )
@@ -166,6 +168,11 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                         default=opts.get(
                             CONF_CONTINUE_CONVERSATION, DEFAULT_CONTINUE_CONVERSATION
                         ),
+                    ): selector.BooleanSelector(),
+                    # ── Web search (beta) ─────────────────────────────────
+                    vol.Optional(
+                        CONF_WEB_SEARCH,
+                        default=opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH),
                     ): selector.BooleanSelector(),
                     # ── STT language ──────────────────────────────────────
                     vol.Optional(

--- a/custom_components/mistral_conversation/const.py
+++ b/custom_components/mistral_conversation/const.py
@@ -11,6 +11,7 @@ CONF_MAX_TOKENS = "max_tokens"
 CONF_TEMPERATURE = "temperature"
 CONF_CONTROL_HA = "control_ha"
 CONF_CONTINUE_CONVERSATION = "continue_conversation"
+CONF_WEB_SEARCH = "web_search"
 CONF_STT_LANGUAGE = "stt_language"
 
 # ---------------------------------------------------------------------------
@@ -21,6 +22,7 @@ DEFAULT_MAX_TOKENS = 1024
 DEFAULT_TEMPERATURE = 0.7          # Mistral range: 0.0–1.0
 DEFAULT_CONTROL_HA = True
 DEFAULT_CONTINUE_CONVERSATION = False
+DEFAULT_WEB_SEARCH = False
 DEFAULT_STT_LANGUAGE = ""          # empty = Voxtral auto-detect
 
 DEFAULT_PROMPT = (
@@ -38,8 +40,16 @@ CHAT_MODELS = [
     "ministral-8b-latest",    # Best for HA: fast, great instruction following, low cost
     "ministral-3b-latest",    # Ultra-fast, lightweight, simple commands
     "mistral-small-latest",   # Balanced: speed + quality
+    "mistral-medium-latest",  # Required for Agents API (web search)
     "mistral-large-latest",   # Most capable, best for complex reasoning
     "open-mistral-nemo",      # Open-source, compact
+]
+
+# Models that support the Agents/Conversations API (required for web search)
+AGENT_CAPABLE_MODELS = [
+    "mistral-medium-latest",
+    "mistral-medium-2505",
+    "mistral-large-latest",
 ]
 
 # ---------------------------------------------------------------------------

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -22,18 +22,21 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    AGENT_CAPABLE_MODELS,
     CONF_CONTINUE_CONVERSATION,
     CONF_CONTROL_HA,
     CONF_MAX_TOKENS,
     CONF_MODEL,
     CONF_PROMPT,
     CONF_TEMPERATURE,
+    CONF_WEB_SEARCH,
     DEFAULT_CONTINUE_CONVERSATION,
     DEFAULT_CONTROL_HA,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL,
     DEFAULT_PROMPT,
     DEFAULT_TEMPERATURE,
+    DEFAULT_WEB_SEARCH,
     DOMAIN,
     MISTRAL_API_BASE,
 )
@@ -234,6 +237,7 @@ class MistralConversationEntity(ConversationEntity):
     async def _process(self, user_input: ConversationInput) -> ConversationResult:
         opts = self._entry.options
         control_ha = opts.get(CONF_CONTROL_HA, DEFAULT_CONTROL_HA)
+        web_search = opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH)
         continue_conversation_enabled = opts.get(
             CONF_CONTINUE_CONVERSATION, DEFAULT_CONTINUE_CONVERSATION
         )
@@ -258,30 +262,41 @@ class MistralConversationEntity(ConversationEntity):
                 "For information requests or general conversation, reply normally in plain text."
             )
 
-        # --- Build message history ----------------------------------------
-        history = self._history.get(conv_id, [])
-        messages = [{"role": "system", "content": system_prompt}]
-        messages.extend(history)
-        messages.append({"role": "user", "content": user_input.text})
-
-        # --- Call Mistral API (streaming) ---------------------------------
         model = opts.get(CONF_MODEL, DEFAULT_MODEL)
         max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
 
-        raw_reply = await self._stream_chat(
-            payload={
-                "model": model,
-                "messages": messages,
-                "max_tokens": max_tokens,
-                "temperature": temperature,
-                "stream": True,
-            },
-            conv_id=conv_id,
-            language=user_input.language,
-        )
+        # --- Choose API path: Conversations (web search) or Chat Completions
+        if web_search and any(model.startswith(m) for m in AGENT_CAPABLE_MODELS):
+            raw_reply = await self._conversations_chat(
+                model=model,
+                system_prompt=system_prompt,
+                user_text=user_input.text,
+                conv_id=conv_id,
+                language=user_input.language,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        else:
+            # --- Build message history ------------------------------------
+            history = self._history.get(conv_id, [])
+            messages = [{"role": "system", "content": system_prompt}]
+            messages.extend(history)
+            messages.append({"role": "user", "content": user_input.text})
 
-        # _stream_chat returns a ConversationResult directly on error
+            raw_reply = await self._stream_chat(
+                payload={
+                    "model": model,
+                    "messages": messages,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    "stream": True,
+                },
+                conv_id=conv_id,
+                language=user_input.language,
+            )
+
+        # _stream_chat / _conversations_chat return ConversationResult on error
         if isinstance(raw_reply, ConversationResult):
             return raw_reply
 
@@ -289,6 +304,7 @@ class MistralConversationEntity(ConversationEntity):
         reply = await self._maybe_execute_service(raw_reply, user_input, control_ha)
 
         # --- Update rolling history (max 20 turns = 40 messages) ----------
+        history = self._history.get(conv_id, [])
         updated_history = list(history)
         updated_history.append({"role": "user", "content": user_input.text})
         updated_history.append({"role": "assistant", "content": raw_reply})
@@ -307,6 +323,135 @@ class MistralConversationEntity(ConversationEntity):
             conversation_id=conv_id,
             continue_conversation=should_continue,
         )
+
+    # ------------------------------------------------------------------
+    # Agents / Conversations API for web search
+    # ------------------------------------------------------------------
+    async def _ensure_web_search_agent(self, model: str, system_prompt: str) -> str:
+        """Create (or reuse) a Mistral Agent with web_search enabled."""
+        runtime = self._runtime
+        if runtime.web_search_agent_id:
+            return runtime.web_search_agent_id
+
+        payload = {
+            "model": model,
+            "name": "HA Mistral Web Search",
+            "description": "Home Assistant conversation agent with web search",
+            "instructions": system_prompt,
+            "tools": [{"type": "web_search"}],
+            "completion_args": {
+                "temperature": 0.3,
+                "top_p": 0.95,
+            },
+        }
+        async with runtime.session.post(
+            f"{MISTRAL_API_BASE}/agents",
+            headers=runtime.headers,
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise HomeAssistantError(
+                    f"Failed to create Mistral web-search agent: {resp.status} {body}"
+                )
+            data = await resp.json()
+            agent_id = data["id"]
+            runtime.web_search_agent_id = agent_id
+            _LOGGER.debug("Created Mistral web-search agent: %s", agent_id)
+            return agent_id
+
+    async def _conversations_chat(
+        self,
+        model: str,
+        system_prompt: str,
+        user_text: str,
+        conv_id: str,
+        language: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str | ConversationResult:
+        """Use the Mistral Conversations API (beta) with web search."""
+        runtime = self._runtime
+        try:
+            agent_id = await self._ensure_web_search_agent(model, system_prompt)
+
+            # Check if we have an existing Mistral conversation_id for this HA conv
+            mistral_conv_id = self._history.get(f"_ws_conv_{conv_id}")
+
+            if mistral_conv_id:
+                # Continue existing conversation
+                url = f"{MISTRAL_API_BASE}/conversations/{mistral_conv_id}"
+                payload = {"inputs": user_text}
+            else:
+                # Start new conversation
+                url = f"{MISTRAL_API_BASE}/conversations"
+                payload = {
+                    "agent_id": agent_id,
+                    "inputs": user_text,
+                }
+
+            async with runtime.session.post(
+                url,
+                headers=runtime.headers,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=90),
+            ) as resp:
+                if resp.status == 401:
+                    raise HomeAssistantError("Invalid Mistral AI API key")
+                if resp.status == 429:
+                    raise HomeAssistantError("Mistral AI rate limit exceeded")
+                if resp.status >= 400:
+                    body = await resp.text()
+                    _LOGGER.error(
+                        "Mistral Conversations API HTTP %s: %s", resp.status, body
+                    )
+                    raise HomeAssistantError(
+                        f"Mistral Conversations API error {resp.status}: {body}"
+                    )
+                data = await resp.json()
+
+            # Store the Mistral conversation_id for follow-ups
+            new_conv_id = data.get("conversation_id") or data.get("id")
+            if new_conv_id:
+                self._history[f"_ws_conv_{conv_id}"] = new_conv_id
+
+            # Extract text from the response outputs
+            return self._extract_conversation_text(data)
+
+        except (aiohttp.ClientError, HomeAssistantError) as err:
+            _LOGGER.error("Mistral Conversations API request failed: %s", err)
+            intent_response = intent.IntentResponse(language=language)
+            intent_response.async_set_error(
+                intent.IntentResponseErrorCode.UNKNOWN,
+                f"Sorry, I could not reach Mistral AI: {err}",
+            )
+            return ConversationResult(
+                response=intent_response, conversation_id=conv_id
+            )
+
+    @staticmethod
+    def _extract_conversation_text(data: dict) -> str:
+        """Extract plain text from a Conversations API response.
+
+        The response contains 'outputs' — a list of entries. Message entries
+        have 'content' which is either a string or a list of chunks with
+        type 'text' or 'tool_reference'. We concatenate the text chunks.
+        """
+        parts: list[str] = []
+        for output in data.get("outputs", []):
+            # Only look at message outputs (skip tool.execution entries)
+            if output.get("type") not in ("message.output", None):
+                if output.get("type") == "tool.execution":
+                    continue
+            content = output.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+            elif isinstance(content, list):
+                for chunk in content:
+                    if isinstance(chunk, dict) and chunk.get("type") == "text":
+                        parts.append(chunk.get("text", ""))
+        return "".join(parts).strip() or data.get("message", "No response from Mistral.")
 
     # ------------------------------------------------------------------
     # Streaming HTTP call (Optimization #4)

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -14,11 +14,10 @@ from homeassistant.components.conversation import (
     ConversationResult,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, MATCH_ALL
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_API_KEY, EVENT_STATE_CHANGED, MATCH_ALL
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.helpers import intent, template
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -150,6 +149,15 @@ class MistralConversationEntity(ConversationEntity):
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_conversation"
         self._history: dict[str, list[dict]] = {}
+        # Cached compiled template — rebuilt only when options change
+        self._cached_prompt_raw: str | None = None
+        self._cached_template: template.Template | None = None
+
+    @property
+    def _runtime(self):
+        """Return the shared MistralRuntimeData for this entry."""
+        from . import MistralRuntimeData
+        return self.hass.data[DOMAIN][self._entry.entry_id]
 
     @property
     def supported_languages(self) -> list[str] | Literal["*"]:
@@ -167,6 +175,42 @@ class MistralConversationEntity(ConversationEntity):
             entry_type=DeviceEntryType.SERVICE,
             configuration_url="https://console.mistral.ai",
         )
+
+    # ------------------------------------------------------------------
+    # Entity context caching (Optimization #2)
+    # ------------------------------------------------------------------
+    def _get_entity_context(self) -> str:
+        """Return cached entity context, rebuilding only on state changes."""
+        runtime = self._runtime
+        if runtime.entity_context is None:
+            runtime.entity_context = _build_entity_context(self.hass)
+            # Subscribe to state changes to invalidate cache
+            if runtime.entity_context_unsub is None:
+                runtime.entity_context_unsub = self.hass.bus.async_listen(
+                    EVENT_STATE_CHANGED, self._on_state_changed
+                )
+        return runtime.entity_context
+
+    async def _on_state_changed(self, event: Event) -> None:
+        """Invalidate entity context cache when any state changes."""
+        self._runtime.entity_context = None
+
+    # ------------------------------------------------------------------
+    # Template caching (Optimization #3)
+    # ------------------------------------------------------------------
+    def _render_system_prompt(self, raw_prompt: str) -> str:
+        """Render the system prompt, reusing the compiled template if unchanged."""
+        if raw_prompt != self._cached_prompt_raw:
+            self._cached_prompt_raw = raw_prompt
+            self._cached_template = template.Template(raw_prompt, self.hass)
+        try:
+            return self._cached_template.async_render(
+                {"ha_name": self.hass.config.location_name},
+                parse_result=False,
+            )
+        except TemplateError as err:
+            _LOGGER.error("Error rendering prompt template: %s", err)
+            return raw_prompt
 
     # ------------------------------------------------------------------
     # HA 2024.6+ API (preferred)
@@ -189,26 +233,18 @@ class MistralConversationEntity(ConversationEntity):
     # ------------------------------------------------------------------
     async def _process(self, user_input: ConversationInput) -> ConversationResult:
         opts = self._entry.options
-        api_key = self._entry.data[CONF_API_KEY]
         control_ha = opts.get(CONF_CONTROL_HA, DEFAULT_CONTROL_HA)
         continue_conversation_enabled = opts.get(
             CONF_CONTINUE_CONVERSATION, DEFAULT_CONTINUE_CONVERSATION
         )
         conv_id = user_input.conversation_id or self._new_id()
 
-        # --- Build system prompt ------------------------------------------
+        # --- Build system prompt (cached template) ------------------------
         raw_prompt = opts.get(CONF_PROMPT, DEFAULT_PROMPT)
-        try:
-            system_prompt = template.Template(raw_prompt, self.hass).async_render(
-                {"ha_name": self.hass.config.location_name},
-                parse_result=False,
-            )
-        except TemplateError as err:
-            _LOGGER.error("Error rendering prompt template: %s", err)
-            system_prompt = raw_prompt
+        system_prompt = self._render_system_prompt(raw_prompt)
 
         if control_ha:
-            ctx = _build_entity_context(self.hass)
+            ctx = self._get_entity_context()  # cached
             if ctx:
                 system_prompt += f"\n\n{ctx}"
             system_prompt += (
@@ -228,24 +264,24 @@ class MistralConversationEntity(ConversationEntity):
         messages.extend(history)
         messages.append({"role": "user", "content": user_input.text})
 
-        # --- Call Mistral API ---------------------------------------------
+        # --- Call Mistral API (streaming) ---------------------------------
         model = opts.get(CONF_MODEL, DEFAULT_MODEL)
         max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
 
-        raw_reply = await self._post_chat(
-            api_key=api_key,
+        raw_reply = await self._stream_chat(
             payload={
                 "model": model,
                 "messages": messages,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
+                "stream": True,
             },
             conv_id=conv_id,
             language=user_input.language,
         )
 
-        # _post_chat returns a ConversationResult directly on error
+        # _stream_chat returns a ConversationResult directly on error
         if isinstance(raw_reply, ConversationResult):
             return raw_reply
 
@@ -259,7 +295,6 @@ class MistralConversationEntity(ConversationEntity):
         self._history[conv_id] = updated_history[-40:]
 
         # --- Decide whether to keep the microphone open -------------------
-        # If enabled, any reply ending with a question keeps listening.
         should_continue = (
             continue_conversation_enabled
             and _reply_contains_question(reply)
@@ -274,26 +309,22 @@ class MistralConversationEntity(ConversationEntity):
         )
 
     # ------------------------------------------------------------------
-    # HTTP call
+    # Streaming HTTP call (Optimization #4)
     # ------------------------------------------------------------------
-    async def _post_chat(
+    async def _stream_chat(
         self,
-        api_key: str,
         payload: dict,
         conv_id: str,
         language: str,
     ) -> str | ConversationResult:
-        """POST to the Mistral chat completions endpoint."""
-        session = async_get_clientsession(self.hass)
+        """Stream from the Mistral chat completions endpoint for faster TTFT."""
+        runtime = self._runtime
         try:
-            async with session.post(
+            async with runtime.session.post(
                 f"{MISTRAL_API_BASE}/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
+                headers=runtime.headers,
                 json=payload,
-                timeout=aiohttp.ClientTimeout(total=30),
+                timeout=aiohttp.ClientTimeout(total=60),
             ) as resp:
                 if resp.status == 401:
                     raise HomeAssistantError("Invalid Mistral AI API key")
@@ -308,7 +339,35 @@ class MistralConversationEntity(ConversationEntity):
                         body,
                     )
                     raise HomeAssistantError(f"Mistral API error {resp.status}: {body}")
-                data = await resp.json()
+
+                # Collect streamed SSE chunks into the full reply
+                chunks: list[str] = []
+                buffer = b""
+                async for raw_chunk in resp.content.iter_any():
+                    buffer += raw_chunk
+                    # SSE lines are separated by \n\n
+                    while b"\n\n" in buffer:
+                        frame, buffer = buffer.split(b"\n\n", 1)
+                        for line in frame.split(b"\n"):
+                            line_str = line.decode("utf-8", errors="replace")
+                            if not line_str.startswith("data: "):
+                                continue
+                            data_str = line_str[6:]
+                            if data_str.strip() == "[DONE]":
+                                break
+                            try:
+                                data = json.loads(data_str)
+                            except json.JSONDecodeError:
+                                continue
+                            delta = (
+                                data.get("choices", [{}])[0]
+                                .get("delta", {})
+                                .get("content")
+                            )
+                            if delta:
+                                chunks.append(delta)
+
+                return "".join(chunks).strip()
 
         except (aiohttp.ClientError, HomeAssistantError) as err:
             _LOGGER.error("Mistral AI request failed: %s", err)
@@ -318,8 +377,6 @@ class MistralConversationEntity(ConversationEntity):
                 f"Sorry, I could not reach Mistral AI: {err}",
             )
             return ConversationResult(response=intent_response, conversation_id=conv_id)
-
-        return data["choices"][0]["message"]["content"].strip()
 
     # ------------------------------------------------------------------
     # HA service execution
@@ -342,16 +399,12 @@ class MistralConversationEntity(ConversationEntity):
         service     = action.get("service", "")
         entity_id   = action.get("entity_id", "")
         service_data = action.get("service_data") or {}
-        # Confirmation is generated by the AI in the user's language
         confirmation = action.get("confirmation", "").strip()
 
         if service not in _ALLOWED_SERVICES.get(domain, []) and domain != "homeassistant":
             _LOGGER.warning("Blocked service call: %s.%s", domain, service)
-            # Return the confirmation if present (AI may have written a refusal),
-            # otherwise fall back to a neutral message.
             return confirmation or f"({domain}.{service} is not permitted)"
 
-        # Merge entity_id into service_data
         call_data: dict = {"entity_id": entity_id, **service_data}
 
         try:
@@ -369,7 +422,6 @@ class MistralConversationEntity(ConversationEntity):
             _LOGGER.exception("Unexpected error executing service %s.%s", domain, service)
             return confirmation or "Something went wrong while executing that action."
 
-        # Return the AI-generated confirmation (already in the user's language)
         return confirmation or entity_id
 
     @staticmethod

--- a/custom_components/mistral_conversation/strings.json
+++ b/custom_components/mistral_conversation/strings.json
@@ -30,6 +30,7 @@
           "max_tokens": "Maximum tokens in response",
           "control_ha": "Allow AI to control Home Assistant devices",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
+          "web_search": "Enable web search (Beta)",
           "stt_language": "Speech recognition language (STT)"
         },
         "data_description": {
@@ -39,6 +40,7 @@
           "max_tokens": "Maximum length of the AI response in tokens.",
           "control_ha": "When enabled the AI can control exposed devices in your home via spoken or typed commands.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
+          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically."
         }
       }

--- a/custom_components/mistral_conversation/stt.py
+++ b/custom_components/mistral_conversation/stt.py
@@ -19,9 +19,7 @@ from homeassistant.components.stt import (
     SpeechToTextEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -186,12 +184,11 @@ class MistralSTTEntity(SpeechToTextEntity):
             sample_width=int(metadata.bit_rate) // 8,
         )
 
-        api_key = self._entry.data[CONF_API_KEY]
         lang_code = (
             self._entry.options.get(CONF_STT_LANGUAGE, DEFAULT_STT_LANGUAGE) or ""
         ).strip()
 
-        session = async_get_clientsession(self.hass)
+        runtime = self.hass.data[DOMAIN][self._entry.entry_id]
         try:
             form = aiohttp.FormData()
             form.add_field(
@@ -204,9 +201,11 @@ class MistralSTTEntity(SpeechToTextEntity):
             if lang_code:
                 form.add_field("language", lang_code)
 
-            async with session.post(
+            # Use only the Authorization header for multipart (no Content-Type override)
+            auth_header = {"Authorization": runtime.headers["Authorization"]}
+            async with runtime.session.post(
                 f"{MISTRAL_API_BASE}/audio/transcriptions",
-                headers={"Authorization": f"Bearer {api_key}"},
+                headers=auth_header,
                 data=form,
                 timeout=aiohttp.ClientTimeout(total=60),
             ) as resp:

--- a/custom_components/mistral_conversation/translations/en.json
+++ b/custom_components/mistral_conversation/translations/en.json
@@ -30,6 +30,7 @@
           "max_tokens": "Maximum tokens in response",
           "control_ha": "Allow AI to control Home Assistant devices",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
+          "web_search": "Enable web search (Beta)",
           "stt_language": "Speech recognition language (STT)"
         },
         "data_description": {
@@ -39,6 +40,7 @@
           "max_tokens": "Maximum length of the AI response in tokens.",
           "control_ha": "When enabled the AI can control exposed devices in your home via spoken or typed commands.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
+          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically."
         }
       }

--- a/custom_components/mistral_conversation/translations/nl.json
+++ b/custom_components/mistral_conversation/translations/nl.json
@@ -30,6 +30,7 @@
           "max_tokens": "Maximaal tokens in antwoord",
           "control_ha": "Laat AI Home Assistant bedienen",
           "continue_conversation": "Gesprekken inschakelen en luisteren naar antwoorden (Experimenteel)",
+          "web_search": "Webzoeken inschakelen (Beta)",
           "stt_language": "Spraakherkenning taal (STT)"
         },
         "data_description": {
@@ -39,6 +40,7 @@
           "max_tokens": "Maximale lengte van het AI-antwoord in tokens.",
           "control_ha": "Als ingeschakeld kan de AI blootgestelde apparaten bedienen via gesproken of getypte opdrachten.",
           "continue_conversation": "Als ingeschakeld blijft de assistent automatisch luisteren na een antwoord dat eindigt met een vraag. Gebruikt de native HA continue_conversation vlag. Experimenteel: gedrag kan per satellite verschillen.",
+          "web_search": "Als ingeschakeld kan de AI het web doorzoeken voor actuele informatie. Gebruikt Mistral's Agents API (beta). Vereist een model dat agents ondersteunt (mistral-medium-latest of mistral-large-latest).",
           "stt_language": "Taal voor Voxtral spraakherkenning. Laat leeg voor automatische detectie."
         }
       }


### PR DESCRIPTION
Depends on: https://github.com/SnarfNL/HA_MistralAI/pull/3 (perf/speed-optimizations) — please merge that first.

This adds optional web search to the conversation agent using Mistral's beta Agents/Conversations API.

How it works:

1. New "Enable web search (Beta)" toggle in the integration options
2. When enabled and the selected model supports agents (mistral-medium-latest or mistral-large-latest), user queries go through the Conversations API with a web_search tool attached
3. When disabled (or using a non-agent model), everything falls back to the regular chat completions endpoint — zero behavior change
4. The Mistral Agent is created lazily on first use and cached for the lifetime of the config entry
5. Conversation continuity is maintained by mapping HA conversation IDs to Mistral conversation IDs

Tested on: Home Assistant with live Mistral API, confirmed it returns current web data for queries like "zoek op wie de minister president is" and "wanneer is koningsdag in 2026".