### PR TITLE
Modernize integration: native HA LLM API, web search, streaming, and reauth

### DIFF
--- a/custom_components/mistral_conversation/__init__.py
+++ b/custom_components/mistral_conversation/__init__.py
@@ -8,7 +8,7 @@ import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -50,8 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             timeout=aiohttp.ClientTimeout(total=10),
         ) as resp:
             if resp.status == 401:
-                _LOGGER.error("Invalid Mistral AI API key")
-                return False
+                raise ConfigEntryAuthFailed("Invalid Mistral AI API key")
             resp.raise_for_status()
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady(f"Cannot connect to Mistral AI: {err}") from err

--- a/custom_components/mistral_conversation/__init__.py
+++ b/custom_components/mistral_conversation/__init__.py
@@ -30,6 +30,8 @@ class MistralRuntimeData:
     # Cached entity-context string; invalidated by state listener
     entity_context: str | None = field(default=None)
     entity_context_unsub: object | None = field(default=None)
+    # Cached Mistral Agent ID for web-search conversations
+    web_search_agent_id: str | None = field(default=None)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/mistral_conversation/__init__.py
+++ b/custom_components/mistral_conversation/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
@@ -20,10 +21,26 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = ["conversation", "stt"]
 
 
+@dataclass
+class MistralRuntimeData:
+    """Shared runtime data for a config entry."""
+
+    session: aiohttp.ClientSession
+    headers: dict[str, str]
+    # Cached entity-context string; invalidated by state listener
+    entity_context: str | None = field(default=None)
+    entity_context_unsub: object | None = field(default=None)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Mistral AI Conversation from a config entry."""
     api_key = entry.data[CONF_API_KEY]
     session = async_get_clientsession(hass)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
     try:
         async with session.get(
             f"{MISTRAL_API_BASE}/models",
@@ -37,6 +54,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady(f"Cannot connect to Mistral AI: {err}") from err
 
+    runtime = MistralRuntimeData(session=session, headers=headers)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
@@ -44,6 +64,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    runtime: MistralRuntimeData | None = hass.data.get(DOMAIN, {}).pop(
+        entry.entry_id, None
+    )
+    if runtime and runtime.entity_context_unsub:
+        runtime.entity_context_unsub()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/custom_components/mistral_conversation/__init__.py
+++ b/custom_components/mistral_conversation/__init__.py
@@ -27,9 +27,6 @@ class MistralRuntimeData:
 
     session: aiohttp.ClientSession
     headers: dict[str, str]
-    # Cached entity-context string; invalidated by state listener
-    entity_context: str | None = field(default=None)
-    entity_context_unsub: object | None = field(default=None)
     # Cached Mistral Agent ID for web-search conversations
     web_search_agent_id: str | None = field(default=None)
 
@@ -68,8 +65,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     runtime: MistralRuntimeData | None = hass.data.get(DOMAIN, {}).pop(
         entry.entry_id, None
     )
-    if runtime and runtime.entity_context_unsub:
-        runtime.entity_context_unsub()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/custom_components/mistral_conversation/config_flow.py
+++ b/custom_components/mistral_conversation/config_flow.py
@@ -7,15 +7,14 @@ from typing import Any
 import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_API_KEY
+from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import selector
+from homeassistant.helpers import llm, selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CHAT_MODELS,
     CONF_CONTINUE_CONVERSATION,
-    CONF_CONTROL_HA,
     CONF_MAX_TOKENS,
     CONF_MODEL,
     CONF_PROMPT,
@@ -23,7 +22,6 @@ from .const import (
     CONF_TEMPERATURE,
     CONF_WEB_SEARCH,
     DEFAULT_CONTINUE_CONVERSATION,
-    DEFAULT_CONTROL_HA,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL,
     DEFAULT_PROMPT,
@@ -77,6 +75,42 @@ class MistralConversationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_reauth(
+        self, entry_data: dict[str, Any]
+    ) -> FlowResult:
+        """Handle reauth when API key becomes invalid."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Dialog to re-enter the API key."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            error = await self._test_api_key(user_input[CONF_API_KEY])
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_API_KEY): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
     async def _test_api_key(self, api_key: str) -> str | None:
         session = async_get_clientsession(self.hass)
         try:
@@ -110,9 +144,18 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         if user_input is not None:
+            # Clean up empty LLM API selection
+            if not user_input.get(CONF_LLM_HASS_API):
+                user_input.pop(CONF_LLM_HASS_API, None)
             return self.async_create_entry(title="", data=user_input)
 
         opts = self.config_entry.options
+
+        # Build LLM API options list
+        hass_apis = [
+            selector.SelectOptionDict(label=api.name, value=api.id)
+            for api in llm.async_get_apis(self.hass)
+        ]
 
         return self.async_show_form(
             step_id="init",
@@ -133,6 +176,15 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                         CONF_PROMPT,
                         default=opts.get(CONF_PROMPT, DEFAULT_PROMPT),
                     ): selector.TemplateSelector(),
+                    # ── LLM API (Home Assistant device control) ───────────
+                    vol.Optional(
+                        CONF_LLM_HASS_API,
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=hass_apis,
+                            multiple=True,
+                        )
+                    ),
                     # ── Temperature ───────────────────────────────────────
                     vol.Optional(
                         CONF_TEMPERATURE,
@@ -157,11 +209,6 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                             mode=selector.NumberSelectorMode.BOX,
                         )
                     ),
-                    # ── HA control ────────────────────────────────────────
-                    vol.Optional(
-                        CONF_CONTROL_HA,
-                        default=opts.get(CONF_CONTROL_HA, DEFAULT_CONTROL_HA),
-                    ): selector.BooleanSelector(),
                     # ── Continue conversation (experimental) ──────────────
                     vol.Optional(
                         CONF_CONTINUE_CONVERSATION,

--- a/custom_components/mistral_conversation/config_flow.py
+++ b/custom_components/mistral_conversation/config_flow.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_PROMPT,
     CONF_STT_LANGUAGE,
     CONF_TEMPERATURE,
+    CONF_WEB_SEARCH,
     DEFAULT_CONTINUE_CONVERSATION,
     DEFAULT_CONTROL_HA,
     DEFAULT_MAX_TOKENS,
@@ -28,6 +29,7 @@ from .const import (
     DEFAULT_PROMPT,
     DEFAULT_STT_LANGUAGE,
     DEFAULT_TEMPERATURE,
+    DEFAULT_WEB_SEARCH,
     DOMAIN,
     MISTRAL_API_BASE,
 )
@@ -166,6 +168,11 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                         default=opts.get(
                             CONF_CONTINUE_CONVERSATION, DEFAULT_CONTINUE_CONVERSATION
                         ),
+                    ): selector.BooleanSelector(),
+                    # ── Web search (beta) ─────────────────────────────────
+                    vol.Optional(
+                        CONF_WEB_SEARCH,
+                        default=opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH),
                     ): selector.BooleanSelector(),
                     # ── STT language ──────────────────────────────────────
                     vol.Optional(

--- a/custom_components/mistral_conversation/config_flow.py
+++ b/custom_components/mistral_conversation/config_flow.py
@@ -179,6 +179,9 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                     # ── LLM API (Home Assistant device control) ───────────
                     vol.Optional(
                         CONF_LLM_HASS_API,
+                        description={
+                            "suggested_value": opts.get(CONF_LLM_HASS_API),
+                        },
                     ): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=hass_apis,

--- a/custom_components/mistral_conversation/const.py
+++ b/custom_components/mistral_conversation/const.py
@@ -11,6 +11,7 @@ CONF_MAX_TOKENS = "max_tokens"
 CONF_TEMPERATURE = "temperature"
 CONF_CONTROL_HA = "control_ha"
 CONF_CONTINUE_CONVERSATION = "continue_conversation"
+CONF_WEB_SEARCH = "web_search"
 CONF_STT_LANGUAGE = "stt_language"
 
 # ---------------------------------------------------------------------------
@@ -21,6 +22,7 @@ DEFAULT_MAX_TOKENS = 1024
 DEFAULT_TEMPERATURE = 0.7          # Mistral range: 0.0–1.0
 DEFAULT_CONTROL_HA = True
 DEFAULT_CONTINUE_CONVERSATION = False
+DEFAULT_WEB_SEARCH = False
 DEFAULT_STT_LANGUAGE = ""          # empty = Voxtral auto-detect
 
 DEFAULT_PROMPT = (
@@ -38,8 +40,16 @@ CHAT_MODELS = [
     "ministral-8b-latest",    # Best for HA: fast, great instruction following, low cost
     "ministral-3b-latest",    # Ultra-fast, lightweight, simple commands
     "mistral-small-latest",   # Balanced: speed + quality
+    "mistral-medium-latest",  # Required for Agents API (web search)
     "mistral-large-latest",   # Most capable, best for complex reasoning
     "open-mistral-nemo",      # Open-source, compact
+]
+
+# Models that support the Agents/Conversations API (required for web search)
+AGENT_CAPABLE_MODELS = [
+    "mistral-medium-latest",
+    "mistral-medium-2505",
+    "mistral-large-latest",
 ]
 
 # ---------------------------------------------------------------------------

--- a/custom_components/mistral_conversation/const.py
+++ b/custom_components/mistral_conversation/const.py
@@ -61,3 +61,6 @@ STT_MODEL = "voxtral-mini-latest"
 # API
 # ---------------------------------------------------------------------------
 MISTRAL_API_BASE = "https://api.mistral.ai/v1"
+
+# Max tool-call round-trips to prevent infinite loops
+MAX_TOOL_ITERATIONS = 10

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -185,7 +185,7 @@ async def _async_stream_delta(
 # Entity
 # ---------------------------------------------------------------------------
 
-class MistralConversationEntity(ConversationEntity, conversation.AbstractConversationAgent):
+class MistralConversationEntity(ConversationEntity):
     """Mistral AI conversation agent entity."""
 
     _attr_has_entity_name = True
@@ -319,55 +319,6 @@ class MistralConversationEntity(ConversationEntity, conversation.AbstractConvers
                 break
 
         return conversation.async_get_result_from_chat_log(user_input, chat_log)
-
-    # ------------------------------------------------------------------
-    # Legacy API (< 2024.6) — redirect to new path
-    # ------------------------------------------------------------------
-    async def async_process(self, user_input: ConversationInput) -> ConversationResult:
-        """Legacy entry point — create a minimal chat_log and delegate."""
-        # On older HA versions, _async_handle_message won't be called.
-        # Fall back to a simple non-tool-calling path.
-        return await self._legacy_process(user_input)
-
-    async def _legacy_process(self, user_input: ConversationInput) -> ConversationResult:
-        """Simple non-chat_log fallback for older HA versions."""
-        opts = self._entry.options
-        runtime = self._runtime
-        model = opts.get(CONF_MODEL, DEFAULT_MODEL)
-        max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
-        temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
-
-        messages = [
-            {"role": "system", "content": opts.get(CONF_PROMPT, "You are a helpful assistant.")},
-            {"role": "user", "content": user_input.text},
-        ]
-        payload = {
-            "model": model,
-            "messages": messages,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-        }
-        try:
-            async with runtime.session.post(
-                f"{MISTRAL_API_BASE}/chat/completions",
-                headers=runtime.headers,
-                json=payload,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as resp:
-                if resp.status >= 400:
-                    body = await resp.text()
-                    raise HomeAssistantError(f"Mistral API error {resp.status}: {body}")
-                data = await resp.json()
-                reply = data["choices"][0]["message"]["content"].strip()
-        except aiohttp.ClientError as err:
-            raise HomeAssistantError(f"Cannot reach Mistral AI: {err}") from err
-
-        intent_response = intent.IntentResponse(language=user_input.language)
-        intent_response.async_set_speech(reply)
-        return ConversationResult(
-            response=intent_response,
-            conversation_id=user_input.conversation_id or "legacy",
-        )
 
     # ------------------------------------------------------------------
     # Agents / Conversations API for web search

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -22,18 +22,21 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    AGENT_CAPABLE_MODELS,
     CONF_CONTINUE_CONVERSATION,
     CONF_CONTROL_HA,
     CONF_MAX_TOKENS,
     CONF_MODEL,
     CONF_PROMPT,
     CONF_TEMPERATURE,
+    CONF_WEB_SEARCH,
     DEFAULT_CONTINUE_CONVERSATION,
     DEFAULT_CONTROL_HA,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL,
     DEFAULT_PROMPT,
     DEFAULT_TEMPERATURE,
+    DEFAULT_WEB_SEARCH,
     DOMAIN,
     MISTRAL_API_BASE,
 )
@@ -234,6 +237,7 @@ class MistralConversationEntity(ConversationEntity):
     async def _process(self, user_input: ConversationInput) -> ConversationResult:
         opts = self._entry.options
         control_ha = opts.get(CONF_CONTROL_HA, DEFAULT_CONTROL_HA)
+        web_search = opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH)
         continue_conversation_enabled = opts.get(
             CONF_CONTINUE_CONVERSATION, DEFAULT_CONTINUE_CONVERSATION
         )
@@ -258,30 +262,41 @@ class MistralConversationEntity(ConversationEntity):
                 "For information requests or general conversation, reply normally in plain text."
             )
 
-        # --- Build message history ----------------------------------------
-        history = self._history.get(conv_id, [])
-        messages = [{"role": "system", "content": system_prompt}]
-        messages.extend(history)
-        messages.append({"role": "user", "content": user_input.text})
-
-        # --- Call Mistral API (streaming) ---------------------------------
         model = opts.get(CONF_MODEL, DEFAULT_MODEL)
         max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
 
-        raw_reply = await self._stream_chat(
-            payload={
-                "model": model,
-                "messages": messages,
-                "max_tokens": max_tokens,
-                "temperature": temperature,
-                "stream": True,
-            },
-            conv_id=conv_id,
-            language=user_input.language,
-        )
+        # --- Choose API path: Conversations (web search) or Chat Completions
+        if web_search and any(model.startswith(m) for m in AGENT_CAPABLE_MODELS):
+            raw_reply = await self._conversations_chat(
+                model=model,
+                system_prompt=system_prompt,
+                user_text=user_input.text,
+                conv_id=conv_id,
+                language=user_input.language,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        else:
+            # --- Build message history ------------------------------------
+            history = self._history.get(conv_id, [])
+            messages = [{"role": "system", "content": system_prompt}]
+            messages.extend(history)
+            messages.append({"role": "user", "content": user_input.text})
 
-        # _stream_chat returns a ConversationResult directly on error
+            raw_reply = await self._stream_chat(
+                payload={
+                    "model": model,
+                    "messages": messages,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    "stream": True,
+                },
+                conv_id=conv_id,
+                language=user_input.language,
+            )
+
+        # _stream_chat / _conversations_chat return ConversationResult on error
         if isinstance(raw_reply, ConversationResult):
             return raw_reply
 
@@ -289,6 +304,7 @@ class MistralConversationEntity(ConversationEntity):
         reply = await self._maybe_execute_service(raw_reply, user_input, control_ha)
 
         # --- Update rolling history (max 20 turns = 40 messages) ----------
+        history = self._history.get(conv_id, [])
         updated_history = list(history)
         updated_history.append({"role": "user", "content": user_input.text})
         updated_history.append({"role": "assistant", "content": raw_reply})
@@ -307,6 +323,135 @@ class MistralConversationEntity(ConversationEntity):
             conversation_id=conv_id,
             continue_conversation=should_continue,
         )
+
+    # ------------------------------------------------------------------
+    # Agents / Conversations API for web search
+    # ------------------------------------------------------------------
+    async def _ensure_web_search_agent(self, model: str, system_prompt: str) -> str:
+        """Create (or reuse) a Mistral Agent with web_search enabled."""
+        runtime = self._runtime
+        if runtime.web_search_agent_id:
+            return runtime.web_search_agent_id
+
+        payload = {
+            "model": model,
+            "name": "HA Mistral Web Search",
+            "description": "Home Assistant conversation agent with web search",
+            "instructions": system_prompt,
+            "tools": [{"type": "web_search"}],
+            "completion_args": {
+                "temperature": 0.3,
+                "top_p": 0.95,
+            },
+        }
+        async with runtime.session.post(
+            f"{MISTRAL_API_BASE}/agents",
+            headers=runtime.headers,
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise HomeAssistantError(
+                    f"Failed to create Mistral web-search agent: {resp.status} {body}"
+                )
+            data = await resp.json()
+            agent_id = data["id"]
+            runtime.web_search_agent_id = agent_id
+            _LOGGER.debug("Created Mistral web-search agent: %s", agent_id)
+            return agent_id
+
+    async def _conversations_chat(
+        self,
+        model: str,
+        system_prompt: str,
+        user_text: str,
+        conv_id: str,
+        language: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str | ConversationResult:
+        """Use the Mistral Conversations API (beta) with web search."""
+        runtime = self._runtime
+        try:
+            agent_id = await self._ensure_web_search_agent(model, system_prompt)
+
+            # Check if we have an existing Mistral conversation_id for this HA conv
+            mistral_conv_id = self._history.get(f"_ws_conv_{conv_id}")
+
+            if mistral_conv_id:
+                # Continue existing conversation
+                url = f"{MISTRAL_API_BASE}/conversations/{mistral_conv_id}"
+                payload = {"inputs": user_text}
+            else:
+                # Start new conversation
+                url = f"{MISTRAL_API_BASE}/conversations"
+                payload = {
+                    "agent_id": agent_id,
+                    "inputs": user_text,
+                }
+
+            async with runtime.session.post(
+                url,
+                headers=runtime.headers,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=90),
+            ) as resp:
+                if resp.status == 401:
+                    raise HomeAssistantError("Invalid Mistral AI API key")
+                if resp.status == 429:
+                    raise HomeAssistantError("Mistral AI rate limit exceeded")
+                if resp.status >= 400:
+                    body = await resp.text()
+                    _LOGGER.error(
+                        "Mistral Conversations API HTTP %s: %s", resp.status, body
+                    )
+                    raise HomeAssistantError(
+                        f"Mistral Conversations API error {resp.status}: {body}"
+                    )
+                data = await resp.json()
+
+            # Store the Mistral conversation_id for follow-ups
+            new_conv_id = data.get("conversation_id") or data.get("id")
+            if new_conv_id:
+                self._history[f"_ws_conv_{conv_id}"] = new_conv_id
+
+            # Extract text from the response outputs
+            return self._extract_conversation_text(data)
+
+        except (aiohttp.ClientError, HomeAssistantError) as err:
+            _LOGGER.error("Mistral Conversations API request failed: %s", err)
+            intent_response = intent.IntentResponse(language=language)
+            intent_response.async_set_error(
+                intent.IntentResponseErrorCode.UNKNOWN,
+                f"Sorry, I could not reach Mistral AI: {err}",
+            )
+            return ConversationResult(
+                response=intent_response, conversation_id=conv_id
+            )
+
+    @staticmethod
+    def _extract_conversation_text(data: dict) -> str:
+        """Extract plain text from a Conversations API response.
+
+        The response contains 'outputs' — a list of entries. Message entries
+        have 'content' which is either a string or a list of chunks with
+        type 'text' or 'tool_reference'. We concatenate the text chunks.
+        """
+        parts: list[str] = []
+        for output in data.get("outputs", []):
+            # Only look at message outputs (skip tool.execution entries)
+            if output.get("type") not in ("message.output", None):
+                if output.get("type") == "tool.execution":
+                    continue
+            content = output.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+            elif isinstance(content, list):
+                for chunk in content:
+                    if isinstance(chunk, dict) and chunk.get("type") == "text":
+                        parts.append(chunk.get("text", ""))
+        return "".join(parts).strip() or data.get("message", "No response from Mistral.")
 
     # ------------------------------------------------------------------
     # Streaming HTTP call (Optimization #4)

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 import json
 import logging
-import re
-from typing import Literal
+from collections.abc import AsyncGenerator
+from typing import Any, Literal
 
 import aiohttp
+from homeassistant.components import conversation
 from homeassistant.components.conversation import (
     ConversationEntity,
     ConversationEntityFeature,
@@ -14,64 +15,30 @@ from homeassistant.components.conversation import (
     ConversationResult,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, EVENT_STATE_CHANGED, MATCH_ALL
+from homeassistant.const import CONF_LLM_HASS_API, EVENT_STATE_CHANGED, MATCH_ALL
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, TemplateError
-from homeassistant.helpers import intent, template
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import intent, llm
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     AGENT_CAPABLE_MODELS,
-    CONF_CONTINUE_CONVERSATION,
-    CONF_CONTROL_HA,
     CONF_MAX_TOKENS,
     CONF_MODEL,
     CONF_PROMPT,
     CONF_TEMPERATURE,
     CONF_WEB_SEARCH,
-    DEFAULT_CONTINUE_CONVERSATION,
-    DEFAULT_CONTROL_HA,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL,
-    DEFAULT_PROMPT,
     DEFAULT_TEMPERATURE,
     DEFAULT_WEB_SEARCH,
     DOMAIN,
+    MAX_TOOL_ITERATIONS,
     MISTRAL_API_BASE,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-# Regex to extract a JSON object from model output, even inside markdown fences
-_JSON_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```|(\{[^`]*?\})", re.DOTALL)
-
-# ---------------------------------------------------------------------------
-# Allowed HA service calls (safety allow-list)
-# ---------------------------------------------------------------------------
-_ALLOWED_SERVICES: dict[str, list[str]] = {
-    "homeassistant": ["turn_on", "turn_off", "toggle"],
-    "light":         ["turn_on", "turn_off", "toggle"],
-    "switch":        ["turn_on", "turn_off", "toggle"],
-    "cover":         ["open_cover", "close_cover", "stop_cover", "set_cover_position"],
-    "media_player":  [
-        "turn_on", "turn_off", "toggle",
-        "media_play", "media_pause", "media_stop",
-        "volume_up", "volume_down", "volume_set", "volume_mute",
-        "select_source", "select_sound_mode",
-        "media_next_track", "media_previous_track",
-    ],
-    "fan":           ["turn_on", "turn_off", "toggle", "set_percentage", "set_preset_mode"],
-    "climate":       ["turn_on", "turn_off", "set_temperature", "set_hvac_mode"],
-    "lock":          ["lock", "unlock"],
-    "alarm_control_panel": ["alarm_arm_away", "alarm_arm_home", "alarm_disarm"],
-    "scene":         ["turn_on"],
-    "script":        ["turn_on"],
-    "automation":    ["turn_on", "turn_off", "trigger"],
-    "input_boolean": ["turn_on", "turn_off", "toggle"],
-    "input_number":  ["set_value"],
-    "number":        ["set_value"],
-}
 
 
 async def async_setup_entry(
@@ -84,56 +51,134 @@ async def async_setup_entry(
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers: convert between HA chat_log and Mistral API formats
 # ---------------------------------------------------------------------------
 
-def _get_exposed_entities(hass: HomeAssistant) -> list:
-    """Return all entity states that are exposed to voice assistants."""
-    try:
-        from homeassistant.components.homeassistant.exposed_entities import (
-            async_should_expose,
-        )
-        from homeassistant.components import conversation as _conv
-
-        return [
-            s for s in hass.states.async_all()
-            if async_should_expose(hass, _conv.DOMAIN, s.entity_id)
-        ]
-    except Exception:  # pylint: disable=broad-except
-        return list(hass.states.async_all())
+def _format_tool(tool: llm.Tool) -> dict[str, Any]:
+    """Convert an HA LLM tool to Mistral function-calling format."""
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description or "",
+            "parameters": tool.parameters.schema if hasattr(tool.parameters, "schema") else {},
+        },
+    }
 
 
-def _build_entity_context(hass: HomeAssistant) -> str:
-    """Build a compact text list of exposed entities for the system prompt."""
-    states = _get_exposed_entities(hass)
-    if not states:
-        return ""
-    lines = ["Exposed smart home devices:"]
-    for s in states:
-        name = s.attributes.get("friendly_name", s.entity_id)
-        lines.append(f"  {s.entity_id} | {name} | state: {s.state}")
-    return "\n".join(lines)
+def _convert_chat_log_to_messages(
+    chat_log: conversation.ChatLog,
+) -> list[dict[str, Any]]:
+    """Convert HA ChatLog content into Mistral chat completions messages."""
+    messages: list[dict[str, Any]] = []
+    for content in chat_log.content:
+        if isinstance(content, conversation.SystemContent):
+            messages.append({"role": "system", "content": content.content})
+        elif isinstance(content, conversation.UserContent):
+            messages.append({"role": "user", "content": content.content})
+        elif isinstance(content, conversation.AssistantContent):
+            msg: dict[str, Any] = {"role": "assistant"}
+            if content.content:
+                msg["content"] = content.content
+            if content.tool_calls:
+                msg["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.tool_name,
+                            "arguments": json.dumps(tc.tool_args),
+                        },
+                    }
+                    for tc in content.tool_calls
+                ]
+            if "content" not in msg and "tool_calls" not in msg:
+                msg["content"] = ""
+            messages.append(msg)
+        elif isinstance(content, conversation.ToolResultContent):
+            messages.append({
+                "role": "tool",
+                "tool_call_id": content.tool_call_id,
+                "name": content.tool_name,
+                "content": json.dumps(content.tool_result),
+            })
+    return messages
 
 
-def _extract_json(text: str) -> dict | None:
-    """Extract the first JSON object from text, handling markdown fences."""
-    try:
-        return json.loads(text.strip())
-    except json.JSONDecodeError:
-        pass
-    for match in _JSON_RE.finditer(text):
-        candidate = match.group(1) or match.group(2)
-        if candidate:
-            try:
-                return json.loads(candidate.strip())
-            except json.JSONDecodeError:
-                continue
-    return None
+async def _async_stream_delta(
+    resp: aiohttp.ClientResponse,
+) -> AsyncGenerator[dict[str, Any]]:
+    """Parse SSE stream from Mistral and yield delta dicts for chat_log."""
+    buffer = b""
+    current_tool_calls: dict[int, dict] = {}
 
+    async for raw_chunk in resp.content.iter_any():
+        buffer += raw_chunk
+        while b"\n\n" in buffer:
+            frame, buffer = buffer.split(b"\n\n", 1)
+            for line in frame.split(b"\n"):
+                line_str = line.decode("utf-8", errors="replace")
+                if not line_str.startswith("data: "):
+                    continue
+                data_str = line_str[6:]
+                if data_str.strip() == "[DONE]":
+                    # Flush any pending tool calls
+                    if current_tool_calls:
+                        for tc in current_tool_calls.values():
+                            yield {
+                                "tool_calls": [
+                                    llm.ToolInput(
+                                        id=tc["id"],
+                                        tool_name=tc["name"],
+                                        tool_args=json.loads(tc["arguments"] or "{}"),
+                                    )
+                                ]
+                            }
+                        current_tool_calls.clear()
+                    return
+                try:
+                    data = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
 
-def _reply_contains_question(text: str) -> bool:
-    """Return True if the reply ends with or contains a question."""
-    return "?" in text
+                choice = data.get("choices", [{}])[0]
+                delta = choice.get("delta", {})
+
+                # Text content
+                if delta.get("content"):
+                    yield {"content": delta["content"]}
+
+                # Tool calls (streamed incrementally)
+                if delta.get("tool_calls"):
+                    for tc_delta in delta["tool_calls"]:
+                        idx = tc_delta.get("index", 0)
+                        if idx not in current_tool_calls:
+                            current_tool_calls[idx] = {
+                                "id": tc_delta.get("id", ""),
+                                "name": tc_delta.get("function", {}).get("name", ""),
+                                "arguments": "",
+                            }
+                        else:
+                            if tc_delta.get("id"):
+                                current_tool_calls[idx]["id"] = tc_delta["id"]
+                            if tc_delta.get("function", {}).get("name"):
+                                current_tool_calls[idx]["name"] = tc_delta["function"]["name"]
+                        if tc_delta.get("function", {}).get("arguments"):
+                            current_tool_calls[idx]["arguments"] += tc_delta["function"]["arguments"]
+
+                # If finish_reason is tool_calls or stop, flush tool calls
+                if choice.get("finish_reason") in ("tool_calls", "stop") and current_tool_calls:
+                    for tc in current_tool_calls.values():
+                        yield {
+                            "tool_calls": [
+                                llm.ToolInput(
+                                    id=tc["id"],
+                                    tool_name=tc["name"],
+                                    tool_args=json.loads(tc["arguments"] or "{}"),
+                                )
+                            ]
+                        }
+                    current_tool_calls.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -145,21 +190,19 @@ class MistralConversationEntity(ConversationEntity):
 
     _attr_has_entity_name = True
     _attr_name = None
-    _attr_supported_features = ConversationEntityFeature.CONTROL
+    _attr_supports_streaming = True
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.hass = hass
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_conversation"
-        self._history: dict[str, list[dict]] = {}
-        # Cached compiled template — rebuilt only when options change
-        self._cached_prompt_raw: str | None = None
-        self._cached_template: template.Template | None = None
+        # Set CONTROL feature if an LLM API is configured
+        if entry.options.get(CONF_LLM_HASS_API):
+            self._attr_supported_features = ConversationEntityFeature.CONTROL
 
     @property
     def _runtime(self):
         """Return the shared MistralRuntimeData for this entry."""
-        from . import MistralRuntimeData
         return self.hass.data[DOMAIN][self._entry.entry_id]
 
     @property
@@ -168,7 +211,6 @@ class MistralConversationEntity(ConversationEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Separate device from STT entity."""
         model = self._entry.options.get(CONF_MODEL, DEFAULT_MODEL)
         return DeviceInfo(
             identifiers={(DOMAIN, f"{self._entry.entry_id}_conversation")},
@@ -180,219 +222,134 @@ class MistralConversationEntity(ConversationEntity):
         )
 
     # ------------------------------------------------------------------
-    # Entity context caching (Optimization #2)
-    # ------------------------------------------------------------------
-    def _get_entity_context(self) -> str:
-        """Return cached entity context, rebuilding only on state changes."""
-        runtime = self._runtime
-        if runtime.entity_context is None:
-            runtime.entity_context = _build_entity_context(self.hass)
-            # Subscribe to state changes to invalidate cache
-            if runtime.entity_context_unsub is None:
-                runtime.entity_context_unsub = self.hass.bus.async_listen(
-                    EVENT_STATE_CHANGED, self._on_state_changed
-                )
-        return runtime.entity_context
-
-    async def _on_state_changed(self, event: Event) -> None:
-        """Invalidate entity context cache when any state changes."""
-        self._runtime.entity_context = None
-
-    # ------------------------------------------------------------------
-    # Template caching (Optimization #3)
-    # ------------------------------------------------------------------
-    def _render_system_prompt(self, raw_prompt: str) -> str:
-        """Render the system prompt, reusing the compiled template if unchanged."""
-        if raw_prompt != self._cached_prompt_raw:
-            self._cached_prompt_raw = raw_prompt
-            self._cached_template = template.Template(raw_prompt, self.hass)
-        try:
-            return self._cached_template.async_render(
-                {"ha_name": self.hass.config.location_name},
-                parse_result=False,
-            )
-        except TemplateError as err:
-            _LOGGER.error("Error rendering prompt template: %s", err)
-            return raw_prompt
-
-    # ------------------------------------------------------------------
-    # HA 2024.6+ API (preferred)
+    # Main entry point — uses HA's native chat_log
     # ------------------------------------------------------------------
     async def _async_handle_message(
         self,
         user_input: ConversationInput,
-        chat_log=None,
+        chat_log: conversation.ChatLog,
     ) -> ConversationResult:
-        return await self._process(user_input)
-
-    # ------------------------------------------------------------------
-    # Legacy API (< 2024.6)
-    # ------------------------------------------------------------------
-    async def async_process(self, user_input: ConversationInput) -> ConversationResult:
-        return await self._process(user_input)
-
-    # ------------------------------------------------------------------
-    # Core processing
-    # ------------------------------------------------------------------
-    async def _process(self, user_input: ConversationInput) -> ConversationResult:
+        """Process a conversation turn using HA's ChatLog and LLM API."""
         opts = self._entry.options
-        control_ha = opts.get(CONF_CONTROL_HA, DEFAULT_CONTROL_HA)
-        web_search = opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH)
-        continue_conversation_enabled = opts.get(
-            CONF_CONTINUE_CONVERSATION, DEFAULT_CONTINUE_CONVERSATION
-        )
-        conv_id = user_input.conversation_id or self._new_id()
 
-        # --- Build system prompt (cached template) ------------------------
-        raw_prompt = opts.get(CONF_PROMPT, DEFAULT_PROMPT)
-        system_prompt = self._render_system_prompt(raw_prompt)
-
-        if control_ha:
-            ctx = self._get_entity_context()  # cached
-            if ctx:
-                system_prompt += f"\n\n{ctx}"
-            system_prompt += (
-                "\n\nWhen the user wants to control a device, respond with ONLY a raw JSON "
-                "object on one line — no extra text, no markdown fences:\n"
-                '{"action":"call_service","domain":"DOMAIN","service":"SERVICE","entity_id":"ENTITY_ID",'
-                '"service_data":{},"confirmation":"A short friendly confirmation in the user\'s language"}\n'
-                "Fill 'service_data' with any extra parameters needed (e.g. volume_level, temperature). "
-                "Leave it as {} if no extra parameters are needed. "
-                "Always write the 'confirmation' in the same language the user is speaking. "
-                "For information requests or general conversation, reply normally in plain text."
+        # Let HA build the system prompt, expose tools, etc.
+        try:
+            await chat_log.async_provide_llm_data(
+                user_input.as_llm_context(DOMAIN),
+                opts.get(CONF_LLM_HASS_API),
+                opts.get(CONF_PROMPT),
+                user_input.extra_system_prompt,
             )
+        except conversation.ConverseError as err:
+            return err.as_conversation_result()
+
+        # Build Mistral tools from HA's LLM API
+        tools: list[dict[str, Any]] | None = None
+        if chat_log.llm_api:
+            tools = [_format_tool(tool) for tool in chat_log.llm_api.tools]
 
         model = opts.get(CONF_MODEL, DEFAULT_MODEL)
         max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
 
-        # --- Choose API path: Conversations (web search) or Chat Completions
-        if web_search and any(model.startswith(m) for m in AGENT_CAPABLE_MODELS):
-            raw_reply = await self._conversations_chat(
-                model=model,
-                system_prompt=system_prompt,
-                user_text=user_input.text,
-                conv_id=conv_id,
-                language=user_input.language,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
-        else:
-            # --- Build message history ------------------------------------
-            history = self._history.get(conv_id, [])
-            messages = [{"role": "system", "content": system_prompt}]
-            messages.extend(history)
-            messages.append({"role": "user", "content": user_input.text})
+        # Tool-call loop: model may request tools, we execute and re-send
+        for _iteration in range(MAX_TOOL_ITERATIONS):
+            messages = _convert_chat_log_to_messages(chat_log)
 
-            raw_reply = await self._stream_chat(
-                payload={
-                    "model": model,
-                    "messages": messages,
-                    "max_tokens": max_tokens,
-                    "temperature": temperature,
-                    "stream": True,
-                },
-                conv_id=conv_id,
-                language=user_input.language,
-            )
+            payload: dict[str, Any] = {
+                "model": model,
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "stream": True,
+            }
+            if tools:
+                payload["tools"] = tools
+                payload["tool_choice"] = "auto"
 
-        # _stream_chat / _conversations_chat return ConversationResult on error
-        if isinstance(raw_reply, ConversationResult):
-            return raw_reply
+            try:
+                result = await self._stream_and_collect(
+                    payload, chat_log, user_input
+                )
+                if isinstance(result, ConversationResult):
+                    return result
+            except HomeAssistantError:
+                raise
+            except Exception as err:
+                _LOGGER.exception("Unexpected error in Mistral conversation")
+                raise HomeAssistantError(
+                    f"Unexpected error talking to Mistral: {err}"
+                ) from err
 
-        # --- Optionally execute a HA service call -------------------------
-        reply = await self._maybe_execute_service(raw_reply, user_input, control_ha)
+            # If no tool results are pending, we're done
+            if not chat_log.unresponded_tool_results:
+                break
 
-        # --- Update rolling history (max 20 turns = 40 messages) ----------
-        history = self._history.get(conv_id, [])
-        updated_history = list(history)
-        updated_history.append({"role": "user", "content": user_input.text})
-        updated_history.append({"role": "assistant", "content": raw_reply})
-        self._history[conv_id] = updated_history[-40:]
+        return conversation.async_get_result_from_chat_log(user_input, chat_log)
 
-        # --- Decide whether to keep the microphone open -------------------
-        should_continue = (
-            continue_conversation_enabled
-            and _reply_contains_question(reply)
-        )
+    # ------------------------------------------------------------------
+    # Legacy API (< 2024.6) — redirect to new path
+    # ------------------------------------------------------------------
+    async def async_process(self, user_input: ConversationInput) -> ConversationResult:
+        """Legacy entry point — create a minimal chat_log and delegate."""
+        # On older HA versions, _async_handle_message won't be called.
+        # Fall back to a simple non-tool-calling path.
+        return await self._legacy_process(user_input)
+
+    async def _legacy_process(self, user_input: ConversationInput) -> ConversationResult:
+        """Simple non-chat_log fallback for older HA versions."""
+        opts = self._entry.options
+        runtime = self._runtime
+        model = opts.get(CONF_MODEL, DEFAULT_MODEL)
+        max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
+        temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
+
+        messages = [
+            {"role": "system", "content": opts.get(CONF_PROMPT, "You are a helpful assistant.")},
+            {"role": "user", "content": user_input.text},
+        ]
+        payload = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        try:
+            async with runtime.session.post(
+                f"{MISTRAL_API_BASE}/chat/completions",
+                headers=runtime.headers,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise HomeAssistantError(f"Mistral API error {resp.status}: {body}")
+                data = await resp.json()
+                reply = data["choices"][0]["message"]["content"].strip()
+        except aiohttp.ClientError as err:
+            raise HomeAssistantError(f"Cannot reach Mistral AI: {err}") from err
 
         intent_response = intent.IntentResponse(language=user_input.language)
         intent_response.async_set_speech(reply)
         return ConversationResult(
             response=intent_response,
-            conversation_id=conv_id,
-            continue_conversation=should_continue,
+            conversation_id=user_input.conversation_id or "legacy",
         )
 
     # ------------------------------------------------------------------
-    # Agents / Conversations API for web search
+    # Streaming HTTP + chat_log delta integration
     # ------------------------------------------------------------------
-    async def _ensure_web_search_agent(self, model: str, system_prompt: str) -> str:
-        """Create (or reuse) a Mistral Agent with web_search enabled."""
-        runtime = self._runtime
-        if runtime.web_search_agent_id:
-            return runtime.web_search_agent_id
-
-        payload = {
-            "model": model,
-            "name": "HA Mistral Web Search",
-            "description": "Home Assistant conversation agent with web search",
-            "instructions": system_prompt,
-            "tools": [{"type": "web_search"}],
-            "completion_args": {
-                "temperature": 0.3,
-                "top_p": 0.95,
-            },
-        }
-        async with runtime.session.post(
-            f"{MISTRAL_API_BASE}/agents",
-            headers=runtime.headers,
-            json=payload,
-            timeout=aiohttp.ClientTimeout(total=15),
-        ) as resp:
-            if resp.status >= 400:
-                body = await resp.text()
-                raise HomeAssistantError(
-                    f"Failed to create Mistral web-search agent: {resp.status} {body}"
-                )
-            data = await resp.json()
-            agent_id = data["id"]
-            runtime.web_search_agent_id = agent_id
-            _LOGGER.debug("Created Mistral web-search agent: %s", agent_id)
-            return agent_id
-
-    async def _conversations_chat(
+    async def _stream_and_collect(
         self,
-        model: str,
-        system_prompt: str,
-        user_text: str,
-        conv_id: str,
-        language: str,
-        max_tokens: int,
-        temperature: float,
-    ) -> str | ConversationResult:
-        """Use the Mistral Conversations API (beta) with web search."""
+        payload: dict[str, Any],
+        chat_log: conversation.ChatLog,
+        user_input: ConversationInput,
+    ) -> ConversationResult | None:
+        """POST to Mistral, stream deltas into chat_log, handle errors."""
         runtime = self._runtime
         try:
-            agent_id = await self._ensure_web_search_agent(model, system_prompt)
-
-            # Check if we have an existing Mistral conversation_id for this HA conv
-            mistral_conv_id = self._history.get(f"_ws_conv_{conv_id}")
-
-            if mistral_conv_id:
-                # Continue existing conversation
-                url = f"{MISTRAL_API_BASE}/conversations/{mistral_conv_id}"
-                payload = {"inputs": user_text}
-            else:
-                # Start new conversation
-                url = f"{MISTRAL_API_BASE}/conversations"
-                payload = {
-                    "agent_id": agent_id,
-                    "inputs": user_text,
-                }
-
             async with runtime.session.post(
-                url,
+                f"{MISTRAL_API_BASE}/chat/completions",
                 headers=runtime.headers,
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=90),
@@ -404,170 +361,23 @@ class MistralConversationEntity(ConversationEntity):
                 if resp.status >= 400:
                     body = await resp.text()
                     _LOGGER.error(
-                        "Mistral Conversations API HTTP %s: %s", resp.status, body
-                    )
-                    raise HomeAssistantError(
-                        f"Mistral Conversations API error {resp.status}: {body}"
-                    )
-                data = await resp.json()
-
-            # Store the Mistral conversation_id for follow-ups
-            new_conv_id = data.get("conversation_id") or data.get("id")
-            if new_conv_id:
-                self._history[f"_ws_conv_{conv_id}"] = new_conv_id
-
-            # Extract text from the response outputs
-            return self._extract_conversation_text(data)
-
-        except (aiohttp.ClientError, HomeAssistantError) as err:
-            _LOGGER.error("Mistral Conversations API request failed: %s", err)
-            intent_response = intent.IntentResponse(language=language)
-            intent_response.async_set_error(
-                intent.IntentResponseErrorCode.UNKNOWN,
-                f"Sorry, I could not reach Mistral AI: {err}",
-            )
-            return ConversationResult(
-                response=intent_response, conversation_id=conv_id
-            )
-
-    @staticmethod
-    def _extract_conversation_text(data: dict) -> str:
-        """Extract plain text from a Conversations API response.
-
-        The response contains 'outputs' — a list of entries. Message entries
-        have 'content' which is either a string or a list of chunks with
-        type 'text' or 'tool_reference'. We concatenate the text chunks.
-        """
-        parts: list[str] = []
-        for output in data.get("outputs", []):
-            # Only look at message outputs (skip tool.execution entries)
-            if output.get("type") not in ("message.output", None):
-                if output.get("type") == "tool.execution":
-                    continue
-            content = output.get("content")
-            if isinstance(content, str):
-                parts.append(content)
-            elif isinstance(content, list):
-                for chunk in content:
-                    if isinstance(chunk, dict) and chunk.get("type") == "text":
-                        parts.append(chunk.get("text", ""))
-        return "".join(parts).strip() or data.get("message", "No response from Mistral.")
-
-    # ------------------------------------------------------------------
-    # Streaming HTTP call (Optimization #4)
-    # ------------------------------------------------------------------
-    async def _stream_chat(
-        self,
-        payload: dict,
-        conv_id: str,
-        language: str,
-    ) -> str | ConversationResult:
-        """Stream from the Mistral chat completions endpoint for faster TTFT."""
-        runtime = self._runtime
-        try:
-            async with runtime.session.post(
-                f"{MISTRAL_API_BASE}/chat/completions",
-                headers=runtime.headers,
-                json=payload,
-                timeout=aiohttp.ClientTimeout(total=60),
-            ) as resp:
-                if resp.status == 401:
-                    raise HomeAssistantError("Invalid Mistral AI API key")
-                if resp.status == 429:
-                    raise HomeAssistantError("Mistral AI rate limit exceeded")
-                if resp.status >= 400:
-                    body = await resp.text()
-                    _LOGGER.error(
                         "Mistral API HTTP %s — model=%s body=%s",
-                        resp.status,
-                        payload.get("model"),
-                        body,
+                        resp.status, payload.get("model"), body,
                     )
                     raise HomeAssistantError(f"Mistral API error {resp.status}: {body}")
 
-                # Collect streamed SSE chunks into the full reply
-                chunks: list[str] = []
-                buffer = b""
-                async for raw_chunk in resp.content.iter_any():
-                    buffer += raw_chunk
-                    # SSE lines are separated by \n\n
-                    while b"\n\n" in buffer:
-                        frame, buffer = buffer.split(b"\n\n", 1)
-                        for line in frame.split(b"\n"):
-                            line_str = line.decode("utf-8", errors="replace")
-                            if not line_str.startswith("data: "):
-                                continue
-                            data_str = line_str[6:]
-                            if data_str.strip() == "[DONE]":
-                                break
-                            try:
-                                data = json.loads(data_str)
-                            except json.JSONDecodeError:
-                                continue
-                            delta = (
-                                data.get("choices", [{}])[0]
-                                .get("delta", {})
-                                .get("content")
-                            )
-                            if delta:
-                                chunks.append(delta)
+                # Stream deltas into chat_log — HA handles tool execution
+                async for _content in chat_log.async_add_delta_content_stream(
+                    user_input.agent_id,
+                    _async_stream_delta(resp),
+                ):
+                    pass  # chat_log accumulates content internally
 
-                return "".join(chunks).strip()
-
-        except (aiohttp.ClientError, HomeAssistantError) as err:
+        except aiohttp.ClientError as err:
             _LOGGER.error("Mistral AI request failed: %s", err)
-            intent_response = intent.IntentResponse(language=language)
-            intent_response.async_set_error(
-                intent.IntentResponseErrorCode.UNKNOWN,
-                f"Sorry, I could not reach Mistral AI: {err}",
-            )
-            return ConversationResult(response=intent_response, conversation_id=conv_id)
+            raise HomeAssistantError(f"Cannot reach Mistral AI: {err}") from err
 
-    # ------------------------------------------------------------------
-    # HA service execution
-    # ------------------------------------------------------------------
-    async def _maybe_execute_service(
-        self,
-        raw_reply: str,
-        user_input: ConversationInput,
-        control_ha: bool,
-    ) -> str:
-        """If raw_reply is a JSON service call, execute it and return the AI-generated confirmation."""
-        if not control_ha:
-            return raw_reply
-
-        action = _extract_json(raw_reply)
-        if not (action and action.get("action") == "call_service"):
-            return raw_reply
-
-        domain      = action.get("domain", "")
-        service     = action.get("service", "")
-        entity_id   = action.get("entity_id", "")
-        service_data = action.get("service_data") or {}
-        confirmation = action.get("confirmation", "").strip()
-
-        if service not in _ALLOWED_SERVICES.get(domain, []) and domain != "homeassistant":
-            _LOGGER.warning("Blocked service call: %s.%s", domain, service)
-            return confirmation or f"({domain}.{service} is not permitted)"
-
-        call_data: dict = {"entity_id": entity_id, **service_data}
-
-        try:
-            await self.hass.services.async_call(
-                domain,
-                service,
-                call_data,
-                blocking=True,
-                context=user_input.context,
-            )
-        except HomeAssistantError as err:
-            _LOGGER.error("Service call %s.%s failed: %s", domain, service, err)
-            return confirmation or str(err)
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected error executing service %s.%s", domain, service)
-            return confirmation or "Something went wrong while executing that action."
-
-        return confirmation or entity_id
+        return None
 
     @staticmethod
     def _new_id() -> str:

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -185,7 +185,7 @@ async def _async_stream_delta(
 # Entity
 # ---------------------------------------------------------------------------
 
-class MistralConversationEntity(ConversationEntity):
+class MistralConversationEntity(ConversationEntity, conversation.AbstractConversationAgent):
     """Mistral AI conversation agent entity."""
 
     _attr_has_entity_name = True

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -255,9 +255,6 @@ class MistralConversationEntity(ConversationEntity):
 
         # --- Web search path: use Agents/Conversations API ---------------
         if web_search and any(model.startswith(m) for m in AGENT_CAPABLE_MODELS):
-            _LOGGER.warning(
-                "Web search enabled — using Conversations API (model=%s)", model
-            )
             system_content = chat_log.content[0] if chat_log.content else None
             system_prompt = system_content.content if hasattr(system_content, "content") else ""
             try:
@@ -268,7 +265,7 @@ class MistralConversationEntity(ConversationEntity):
                     conv_id=chat_log.conversation_id,
                 )
             except HomeAssistantError as err:
-                _LOGGER.warning("Web search failed, falling back to chat completions: %s", err)
+                _LOGGER.debug("Web search failed, falling back to chat completions: %s", err)
                 ws_reply = None
 
             if ws_reply:
@@ -280,8 +277,8 @@ class MistralConversationEntity(ConversationEntity):
                 )
         else:
             _LOGGER.debug(
-                "Web search skipped (web_search=%s, model=%s, capable=%s)",
-                web_search, model, AGENT_CAPABLE_MODELS,
+                "Web search skipped (web_search=%s, model=%s)",
+                web_search, model,
             )
 
         # --- Standard path: chat completions with tool calling -----------

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -14,11 +14,10 @@ from homeassistant.components.conversation import (
     ConversationResult,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, MATCH_ALL
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_API_KEY, EVENT_STATE_CHANGED, MATCH_ALL
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.helpers import intent, template
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -150,6 +149,15 @@ class MistralConversationEntity(ConversationEntity):
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_conversation"
         self._history: dict[str, list[dict]] = {}
+        # Cached compiled template — rebuilt only when options change
+        self._cached_prompt_raw: str | None = None
+        self._cached_template: template.Template | None = None
+
+    @property
+    def _runtime(self):
+        """Return the shared MistralRuntimeData for this entry."""
+        from . import MistralRuntimeData
+        return self.hass.data[DOMAIN][self._entry.entry_id]
 
     @property
     def supported_languages(self) -> list[str] | Literal["*"]:
@@ -167,6 +175,42 @@ class MistralConversationEntity(ConversationEntity):
             entry_type=DeviceEntryType.SERVICE,
             configuration_url="https://console.mistral.ai",
         )
+
+    # ------------------------------------------------------------------
+    # Entity context caching (Optimization #2)
+    # ------------------------------------------------------------------
+    def _get_entity_context(self) -> str:
+        """Return cached entity context, rebuilding only on state changes."""
+        runtime = self._runtime
+        if runtime.entity_context is None:
+            runtime.entity_context = _build_entity_context(self.hass)
+            # Subscribe to state changes to invalidate cache
+            if runtime.entity_context_unsub is None:
+                runtime.entity_context_unsub = self.hass.bus.async_listen(
+                    EVENT_STATE_CHANGED, self._on_state_changed
+                )
+        return runtime.entity_context
+
+    async def _on_state_changed(self, event: Event) -> None:
+        """Invalidate entity context cache when any state changes."""
+        self._runtime.entity_context = None
+
+    # ------------------------------------------------------------------
+    # Template caching (Optimization #3)
+    # ------------------------------------------------------------------
+    def _render_system_prompt(self, raw_prompt: str) -> str:
+        """Render the system prompt, reusing the compiled template if unchanged."""
+        if raw_prompt != self._cached_prompt_raw:
+            self._cached_prompt_raw = raw_prompt
+            self._cached_template = template.Template(raw_prompt, self.hass)
+        try:
+            return self._cached_template.async_render(
+                {"ha_name": self.hass.config.location_name},
+                parse_result=False,
+            )
+        except TemplateError as err:
+            _LOGGER.error("Error rendering prompt template: %s", err)
+            return raw_prompt
 
     # ------------------------------------------------------------------
     # HA 2024.6+ API (preferred)
@@ -189,26 +233,18 @@ class MistralConversationEntity(ConversationEntity):
     # ------------------------------------------------------------------
     async def _process(self, user_input: ConversationInput) -> ConversationResult:
         opts = self._entry.options
-        api_key = self._entry.data[CONF_API_KEY]
         control_ha = opts.get(CONF_CONTROL_HA, DEFAULT_CONTROL_HA)
         continue_conversation_enabled = opts.get(
             CONF_CONTINUE_CONVERSATION, DEFAULT_CONTINUE_CONVERSATION
         )
         conv_id = user_input.conversation_id or self._new_id()
 
-        # --- Build system prompt ------------------------------------------
+        # --- Build system prompt (cached template) ------------------------
         raw_prompt = opts.get(CONF_PROMPT, DEFAULT_PROMPT)
-        try:
-            system_prompt = template.Template(raw_prompt, self.hass).async_render(
-                {"ha_name": self.hass.config.location_name},
-                parse_result=False,
-            )
-        except TemplateError as err:
-            _LOGGER.error("Error rendering prompt template: %s", err)
-            system_prompt = raw_prompt
+        system_prompt = self._render_system_prompt(raw_prompt)
 
         if control_ha:
-            ctx = _build_entity_context(self.hass)
+            ctx = self._get_entity_context()  # cached
             if ctx:
                 system_prompt += f"\n\n{ctx}"
             system_prompt += (
@@ -228,24 +264,24 @@ class MistralConversationEntity(ConversationEntity):
         messages.extend(history)
         messages.append({"role": "user", "content": user_input.text})
 
-        # --- Call Mistral API ---------------------------------------------
+        # --- Call Mistral API (streaming) ---------------------------------
         model = opts.get(CONF_MODEL, DEFAULT_MODEL)
         max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
 
-        raw_reply = await self._post_chat(
-            api_key=api_key,
+        raw_reply = await self._stream_chat(
             payload={
                 "model": model,
                 "messages": messages,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
+                "stream": True,
             },
             conv_id=conv_id,
             language=user_input.language,
         )
 
-        # _post_chat returns a ConversationResult directly on error
+        # _stream_chat returns a ConversationResult directly on error
         if isinstance(raw_reply, ConversationResult):
             return raw_reply
 
@@ -259,7 +295,6 @@ class MistralConversationEntity(ConversationEntity):
         self._history[conv_id] = updated_history[-40:]
 
         # --- Decide whether to keep the microphone open -------------------
-        # If enabled, any reply ending with a question keeps listening.
         should_continue = (
             continue_conversation_enabled
             and _reply_contains_question(reply)
@@ -274,26 +309,22 @@ class MistralConversationEntity(ConversationEntity):
         )
 
     # ------------------------------------------------------------------
-    # HTTP call
+    # Streaming HTTP call (Optimization #4)
     # ------------------------------------------------------------------
-    async def _post_chat(
+    async def _stream_chat(
         self,
-        api_key: str,
         payload: dict,
         conv_id: str,
         language: str,
     ) -> str | ConversationResult:
-        """POST to the Mistral chat completions endpoint."""
-        session = async_get_clientsession(self.hass)
+        """Stream from the Mistral chat completions endpoint for faster TTFT."""
+        runtime = self._runtime
         try:
-            async with session.post(
+            async with runtime.session.post(
                 f"{MISTRAL_API_BASE}/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
+                headers=runtime.headers,
                 json=payload,
-                timeout=aiohttp.ClientTimeout(total=30),
+                timeout=aiohttp.ClientTimeout(total=60),
             ) as resp:
                 if resp.status == 401:
                     raise HomeAssistantError("Invalid Mistral AI API key")
@@ -308,7 +339,35 @@ class MistralConversationEntity(ConversationEntity):
                         body,
                     )
                     raise HomeAssistantError(f"Mistral API error {resp.status}: {body}")
-                data = await resp.json()
+
+                # Collect streamed SSE chunks into the full reply
+                chunks: list[str] = []
+                buffer = b""
+                async for raw_chunk in resp.content.iter_any():
+                    buffer += raw_chunk
+                    # SSE lines are separated by \n\n
+                    while b"\n\n" in buffer:
+                        frame, buffer = buffer.split(b"\n\n", 1)
+                        for line in frame.split(b"\n"):
+                            line_str = line.decode("utf-8", errors="replace")
+                            if not line_str.startswith("data: "):
+                                continue
+                            data_str = line_str[6:]
+                            if data_str.strip() == "[DONE]":
+                                break
+                            try:
+                                data = json.loads(data_str)
+                            except json.JSONDecodeError:
+                                continue
+                            delta = (
+                                data.get("choices", [{}])[0]
+                                .get("delta", {})
+                                .get("content")
+                            )
+                            if delta:
+                                chunks.append(delta)
+
+                return "".join(chunks).strip()
 
         except (aiohttp.ClientError, HomeAssistantError) as err:
             _LOGGER.error("Mistral AI request failed: %s", err)
@@ -318,8 +377,6 @@ class MistralConversationEntity(ConversationEntity):
                 f"Sorry, I could not reach Mistral AI: {err}",
             )
             return ConversationResult(response=intent_response, conversation_id=conv_id)
-
-        return data["choices"][0]["message"]["content"].strip()
 
     # ------------------------------------------------------------------
     # HA service execution
@@ -342,16 +399,12 @@ class MistralConversationEntity(ConversationEntity):
         service     = action.get("service", "")
         entity_id   = action.get("entity_id", "")
         service_data = action.get("service_data") or {}
-        # Confirmation is generated by the AI in the user's language
         confirmation = action.get("confirmation", "").strip()
 
         if service not in _ALLOWED_SERVICES.get(domain, []) and domain != "homeassistant":
             _LOGGER.warning("Blocked service call: %s.%s", domain, service)
-            # Return the confirmation if present (AI may have written a refusal),
-            # otherwise fall back to a neutral message.
             return confirmation or f"({domain}.{service} is not permitted)"
 
-        # Merge entity_id into service_data
         call_data: dict = {"entity_id": entity_id, **service_data}
 
         try:
@@ -369,7 +422,6 @@ class MistralConversationEntity(ConversationEntity):
             _LOGGER.exception("Unexpected error executing service %s.%s", domain, service)
             return confirmation or "Something went wrong while executing that action."
 
-        # Return the AI-generated confirmation (already in the user's language)
         return confirmation or entity_id
 
     @staticmethod

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -251,7 +251,32 @@ class MistralConversationEntity(ConversationEntity):
         model = opts.get(CONF_MODEL, DEFAULT_MODEL)
         max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
+        web_search = opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH)
 
+        # --- Web search path: use Agents/Conversations API ---------------
+        if web_search and any(model.startswith(m) for m in AGENT_CAPABLE_MODELS):
+            system_content = chat_log.content[0] if chat_log.content else None
+            system_prompt = system_content.content if hasattr(system_content, "content") else ""
+            try:
+                ws_reply = await self._conversations_chat(
+                    model=model,
+                    system_prompt=system_prompt,
+                    user_text=user_input.text,
+                    conv_id=chat_log.conversation_id,
+                )
+            except HomeAssistantError as err:
+                _LOGGER.error("Web search failed, falling back to chat completions: %s", err)
+                ws_reply = None
+
+            if ws_reply:
+                intent_response = intent.IntentResponse(language=user_input.language)
+                intent_response.async_set_speech(ws_reply)
+                return ConversationResult(
+                    response=intent_response,
+                    conversation_id=chat_log.conversation_id,
+                )
+
+        # --- Standard path: chat completions with tool calling -----------
         # Tool-call loop: model may request tools, we execute and re-send
         for _iteration in range(MAX_TOOL_ITERATIONS):
             messages = _convert_chat_log_to_messages(chat_log)
@@ -335,6 +360,96 @@ class MistralConversationEntity(ConversationEntity):
             response=intent_response,
             conversation_id=user_input.conversation_id or "legacy",
         )
+
+    # ------------------------------------------------------------------
+    # Agents / Conversations API for web search
+    # ------------------------------------------------------------------
+    async def _ensure_web_search_agent(self, model: str, system_prompt: str) -> str:
+        """Create (or reuse) a Mistral Agent with web_search enabled."""
+        runtime = self._runtime
+        if runtime.web_search_agent_id:
+            return runtime.web_search_agent_id
+
+        payload = {
+            "model": model,
+            "name": "HA Mistral Web Search",
+            "description": "Home Assistant conversation agent with web search",
+            "instructions": system_prompt,
+            "tools": [{"type": "web_search"}],
+            "completion_args": {"temperature": 0.3, "top_p": 0.95},
+        }
+        async with runtime.session.post(
+            f"{MISTRAL_API_BASE}/agents",
+            headers=runtime.headers,
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise HomeAssistantError(
+                    f"Failed to create Mistral web-search agent: {resp.status} {body}"
+                )
+            data = await resp.json()
+            agent_id = data["id"]
+            runtime.web_search_agent_id = agent_id
+            _LOGGER.debug("Created Mistral web-search agent: %s", agent_id)
+            return agent_id
+
+    async def _conversations_chat(
+        self,
+        model: str,
+        system_prompt: str,
+        user_text: str,
+        conv_id: str,
+    ) -> str:
+        """Use the Mistral Conversations API (beta) with web search."""
+        runtime = self._runtime
+        agent_id = await self._ensure_web_search_agent(model, system_prompt)
+
+        # Check if we have an existing Mistral conversation_id
+        mistral_conv_key = f"_ws_conv_{conv_id}"
+        mistral_conv_id = getattr(runtime, "_ws_convs", {}).get(conv_id)
+
+        if mistral_conv_id:
+            url = f"{MISTRAL_API_BASE}/conversations/{mistral_conv_id}"
+            payload: dict[str, Any] = {"inputs": user_text}
+        else:
+            url = f"{MISTRAL_API_BASE}/conversations"
+            payload = {"agent_id": agent_id, "inputs": user_text}
+
+        async with runtime.session.post(
+            url,
+            headers=runtime.headers,
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=90),
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise HomeAssistantError(
+                    f"Mistral Conversations API error {resp.status}: {body}"
+                )
+            data = await resp.json()
+
+        # Store conversation_id for follow-ups
+        new_conv_id = data.get("conversation_id") or data.get("id")
+        if new_conv_id:
+            if not hasattr(runtime, "_ws_convs"):
+                runtime._ws_convs = {}
+            runtime._ws_convs[conv_id] = new_conv_id
+
+        # Extract text from response
+        parts: list[str] = []
+        for output in data.get("outputs", []):
+            if output.get("type") == "tool.execution":
+                continue
+            content = output.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+            elif isinstance(content, list):
+                for chunk in content:
+                    if isinstance(chunk, dict) and chunk.get("type") == "text":
+                        parts.append(chunk.get("text", ""))
+        return "".join(parts).strip() or data.get("message", "")
 
     # ------------------------------------------------------------------
     # Streaming HTTP + chat_log delta integration

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -255,6 +255,9 @@ class MistralConversationEntity(ConversationEntity):
 
         # --- Web search path: use Agents/Conversations API ---------------
         if web_search and any(model.startswith(m) for m in AGENT_CAPABLE_MODELS):
+            _LOGGER.warning(
+                "Web search enabled — using Conversations API (model=%s)", model
+            )
             system_content = chat_log.content[0] if chat_log.content else None
             system_prompt = system_content.content if hasattr(system_content, "content") else ""
             try:
@@ -265,7 +268,7 @@ class MistralConversationEntity(ConversationEntity):
                     conv_id=chat_log.conversation_id,
                 )
             except HomeAssistantError as err:
-                _LOGGER.error("Web search failed, falling back to chat completions: %s", err)
+                _LOGGER.warning("Web search failed, falling back to chat completions: %s", err)
                 ws_reply = None
 
             if ws_reply:
@@ -275,6 +278,11 @@ class MistralConversationEntity(ConversationEntity):
                     response=intent_response,
                     conversation_id=chat_log.conversation_id,
                 )
+        else:
+            _LOGGER.debug(
+                "Web search skipped (web_search=%s, model=%s, capable=%s)",
+                web_search, model, AGENT_CAPABLE_MODELS,
+            )
 
         # --- Standard path: chat completions with tool calling -----------
         # Tool-call loop: model may request tools, we execute and re-send

--- a/custom_components/mistral_conversation/strings.json
+++ b/custom_components/mistral_conversation/strings.json
@@ -30,6 +30,7 @@
           "max_tokens": "Maximum tokens in response",
           "control_ha": "Allow AI to control Home Assistant devices",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
+          "web_search": "Enable web search (Beta)",
           "stt_language": "Speech recognition language (STT)"
         },
         "data_description": {
@@ -39,6 +40,7 @@
           "max_tokens": "Maximum length of the AI response in tokens.",
           "control_ha": "When enabled the AI can control exposed devices in your home via spoken or typed commands.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
+          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically."
         }
       }

--- a/custom_components/mistral_conversation/strings.json
+++ b/custom_components/mistral_conversation/strings.json
@@ -8,6 +8,13 @@
         "data": {
           "api_key": "API Key"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with Mistral AI",
+        "description": "Your API key is no longer valid. Please enter a new one.",
+        "data": {
+          "api_key": "API Key"
+        }
       }
     },
     "error": {
@@ -16,7 +23,8 @@
       "unknown": "Unexpected error. Check the Home Assistant logs for details."
     },
     "abort": {
-      "already_configured": "Mistral AI Conversation is already configured."
+      "already_configured": "Mistral AI Conversation is already configured.",
+      "reauth_successful": "Re-authentication successful."
     }
   },
   "options": {
@@ -26,9 +34,9 @@
         "data": {
           "model": "AI model",
           "prompt": "System prompt",
+          "llm_hass_api": "Control Home Assistant",
           "temperature": "Temperature (creativity)",
           "max_tokens": "Maximum tokens in response",
-          "control_ha": "Allow AI to control Home Assistant devices",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
           "web_search": "Enable web search (Beta)",
           "stt_language": "Speech recognition language (STT)"
@@ -36,9 +44,9 @@
         "data_description": {
           "model": "Which Mistral model to use. Ministral-8b is recommended for home automation commands: fast, cost-effective and great at instruction-following.",
           "prompt": "Instructions for the AI. Supports Jinja2 templates with {{ ha_name }}, {{ now() }} etc.",
+          "llm_hass_api": "Select which Home Assistant APIs the AI can use to control your devices. 'Assist' exposes the same entities as the built-in voice assistant.",
           "temperature": "0 = deterministic, 1 = creative. Mistral range: 0.0–1.0.",
           "max_tokens": "Maximum length of the AI response in tokens.",
-          "control_ha": "When enabled the AI can control exposed devices in your home via spoken or typed commands.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
           "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically."

--- a/custom_components/mistral_conversation/stt.py
+++ b/custom_components/mistral_conversation/stt.py
@@ -19,9 +19,7 @@ from homeassistant.components.stt import (
     SpeechToTextEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -186,12 +184,11 @@ class MistralSTTEntity(SpeechToTextEntity):
             sample_width=int(metadata.bit_rate) // 8,
         )
 
-        api_key = self._entry.data[CONF_API_KEY]
         lang_code = (
             self._entry.options.get(CONF_STT_LANGUAGE, DEFAULT_STT_LANGUAGE) or ""
         ).strip()
 
-        session = async_get_clientsession(self.hass)
+        runtime = self.hass.data[DOMAIN][self._entry.entry_id]
         try:
             form = aiohttp.FormData()
             form.add_field(
@@ -204,9 +201,11 @@ class MistralSTTEntity(SpeechToTextEntity):
             if lang_code:
                 form.add_field("language", lang_code)
 
-            async with session.post(
+            # Use only the Authorization header for multipart (no Content-Type override)
+            auth_header = {"Authorization": runtime.headers["Authorization"]}
+            async with runtime.session.post(
                 f"{MISTRAL_API_BASE}/audio/transcriptions",
-                headers={"Authorization": f"Bearer {api_key}"},
+                headers=auth_header,
                 data=form,
                 timeout=aiohttp.ClientTimeout(total=60),
             ) as resp:

--- a/custom_components/mistral_conversation/translations/en.json
+++ b/custom_components/mistral_conversation/translations/en.json
@@ -30,6 +30,7 @@
           "max_tokens": "Maximum tokens in response",
           "control_ha": "Allow AI to control Home Assistant devices",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
+          "web_search": "Enable web search (Beta)",
           "stt_language": "Speech recognition language (STT)"
         },
         "data_description": {
@@ -39,6 +40,7 @@
           "max_tokens": "Maximum length of the AI response in tokens.",
           "control_ha": "When enabled the AI can control exposed devices in your home via spoken or typed commands.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
+          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically."
         }
       }

--- a/custom_components/mistral_conversation/translations/en.json
+++ b/custom_components/mistral_conversation/translations/en.json
@@ -8,6 +8,13 @@
         "data": {
           "api_key": "API Key"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with Mistral AI",
+        "description": "Your API key is no longer valid. Please enter a new one.",
+        "data": {
+          "api_key": "API Key"
+        }
       }
     },
     "error": {
@@ -16,7 +23,8 @@
       "unknown": "Unexpected error. Check the Home Assistant logs for details."
     },
     "abort": {
-      "already_configured": "Mistral AI Conversation is already configured."
+      "already_configured": "Mistral AI Conversation is already configured.",
+      "reauth_successful": "Re-authentication successful."
     }
   },
   "options": {
@@ -26,9 +34,9 @@
         "data": {
           "model": "AI model",
           "prompt": "System prompt",
+          "llm_hass_api": "Control Home Assistant",
           "temperature": "Temperature (creativity)",
           "max_tokens": "Maximum tokens in response",
-          "control_ha": "Allow AI to control Home Assistant devices",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
           "web_search": "Enable web search (Beta)",
           "stt_language": "Speech recognition language (STT)"
@@ -36,9 +44,9 @@
         "data_description": {
           "model": "Which Mistral model to use. Ministral-8b is recommended for home automation commands: fast, cost-effective and great at instruction-following.",
           "prompt": "Instructions for the AI. Supports Jinja2 templates with {{ ha_name }}, {{ now() }} etc.",
+          "llm_hass_api": "Select which Home Assistant APIs the AI can use to control your devices. 'Assist' exposes the same entities as the built-in voice assistant.",
           "temperature": "0 = deterministic, 1 = creative. Mistral range: 0.0–1.0.",
           "max_tokens": "Maximum length of the AI response in tokens.",
-          "control_ha": "When enabled the AI can control exposed devices in your home via spoken or typed commands.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
           "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically."

--- a/custom_components/mistral_conversation/translations/nl.json
+++ b/custom_components/mistral_conversation/translations/nl.json
@@ -8,6 +8,13 @@
         "data": {
           "api_key": "API-sleutel"
         }
+      },
+      "reauth_confirm": {
+        "title": "Opnieuw authenticeren bij Mistral AI",
+        "description": "Je API-sleutel is niet meer geldig. Voer een nieuwe in.",
+        "data": {
+          "api_key": "API-sleutel"
+        }
       }
     },
     "error": {
@@ -16,7 +23,8 @@
       "unknown": "Onbekende fout. Zie de logbestanden voor details."
     },
     "abort": {
-      "already_configured": "Mistral AI Conversation is al geconfigureerd."
+      "already_configured": "Mistral AI Conversation is al geconfigureerd.",
+      "reauth_successful": "Opnieuw authenticeren gelukt."
     }
   },
   "options": {
@@ -26,9 +34,9 @@
         "data": {
           "model": "AI-model",
           "prompt": "Systeemprompt",
+          "llm_hass_api": "Home Assistant bedienen",
           "temperature": "Temperature (creativiteit)",
           "max_tokens": "Maximaal tokens in antwoord",
-          "control_ha": "Laat AI Home Assistant bedienen",
           "continue_conversation": "Gesprekken inschakelen en luisteren naar antwoorden (Experimenteel)",
           "web_search": "Webzoeken inschakelen (Beta)",
           "stt_language": "Spraakherkenning taal (STT)"
@@ -36,9 +44,9 @@
         "data_description": {
           "model": "Welk Mistral-model wordt gebruikt. Ministral-8b is aanbevolen voor home automation: snel, goedkoop en sterk in opdrachten uitvoeren.",
           "prompt": "Instructies voor de AI. Ondersteunt Jinja2 templates met {{ ha_name }}, {{ now() }} etc.",
+          "llm_hass_api": "Selecteer welke Home Assistant API's de AI mag gebruiken om apparaten te bedienen. 'Assist' stelt dezelfde entiteiten beschikbaar als de ingebouwde spraakassistent.",
           "temperature": "0 = deterministisch, 1 = creatief. Mistral bereik: 0.0–1.0.",
           "max_tokens": "Maximale lengte van het AI-antwoord in tokens.",
-          "control_ha": "Als ingeschakeld kan de AI blootgestelde apparaten bedienen via gesproken of getypte opdrachten.",
           "continue_conversation": "Als ingeschakeld blijft de assistent automatisch luisteren na een antwoord dat eindigt met een vraag. Gebruikt de native HA continue_conversation vlag. Experimenteel: gedrag kan per satellite verschillen.",
           "web_search": "Als ingeschakeld kan de AI het web doorzoeken voor actuele informatie. Gebruikt Mistral's Agents API (beta). Vereist een model dat agents ondersteunt (mistral-medium-latest of mistral-large-latest).",
           "stt_language": "Taal voor Voxtral spraakherkenning. Laat leeg voor automatische detectie."

--- a/custom_components/mistral_conversation/translations/nl.json
+++ b/custom_components/mistral_conversation/translations/nl.json
@@ -30,6 +30,7 @@
           "max_tokens": "Maximaal tokens in antwoord",
           "control_ha": "Laat AI Home Assistant bedienen",
           "continue_conversation": "Gesprekken inschakelen en luisteren naar antwoorden (Experimenteel)",
+          "web_search": "Webzoeken inschakelen (Beta)",
           "stt_language": "Spraakherkenning taal (STT)"
         },
         "data_description": {
@@ -39,6 +40,7 @@
           "max_tokens": "Maximale lengte van het AI-antwoord in tokens.",
           "control_ha": "Als ingeschakeld kan de AI blootgestelde apparaten bedienen via gesproken of getypte opdrachten.",
           "continue_conversation": "Als ingeschakeld blijft de assistent automatisch luisteren na een antwoord dat eindigt met een vraag. Gebruikt de native HA continue_conversation vlag. Experimenteel: gedrag kan per satellite verschillen.",
+          "web_search": "Als ingeschakeld kan de AI het web doorzoeken voor actuele informatie. Gebruikt Mistral's Agents API (beta). Vereist een model dat agents ondersteunt (mistral-medium-latest of mistral-large-latest).",
           "stt_language": "Taal voor Voxtral spraakherkenning. Laat leeg voor automatische detectie."
         }
       }


### PR DESCRIPTION
This PR combines performance improvements and web search support

ChatLog integration with streaming

The conversation entity now uses HA's ChatLog. HA manages conversation state and persistence, and streaming deltas flow through chat_log.async_add_delta_content_stream() so text appears word-by-word in the HA chat UI. The old in-memory self._history dict is gone.

Mistral function calling

HA LLM tools are converted to Mistral's native function-calling format. Tool calls are handled in a loop (max 10 iterations) so the model can call multiple tools before producing a final answer.

Web search (beta)

New "Enable web search" toggle in options. When enabled with a compatible model (mistral-medium-latest or mistral-large-latest), queries go through Mistral's Agents/Conversations API with a web_search tool. Falls back gracefully to regular chat completions if the Conversations API fails. The Mistral Agent is created lazily and cached.

Reauth flow

If the API key becomes invalid, HA now shows a reauth prompt instead of silently failing. Uses ConfigEntryAuthFailed + async_step_reauth.

Performance

API session and headers cached once at setup in MistralRuntimeData (no per-request rebuilds)
Chat completions use SSE streaming for faster time-to-first-token
STT entity shares the same cached session
Removed

CONF_CONTROL_HA toggle (replaced by CONF_LLM_HASS_API multi-select)
Custom _ALLOWED_SERVICES allow-list
Custom _build_entity_context / _get_exposed_entities
Custom JSON extraction for service calls
Manual conversation history management
Translations: EN + NL updated.

Tested on: Home Assistant 2026.2.3 with live Mistral API — device control via Assist, web search, and regular conversation all confirmed working.