### PR TITLE
Fix/tool call id length

### DIFF
--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -148,6 +148,20 @@ def _convert_chat_log_to_messages(
 
         elif isinstance(content, conversation.AssistantContent):
             if content.tool_calls:
+                # Check if ALL tool calls have matching results
+                all_have_results = all(
+                    tc.id in tool_results for tc in content.tool_calls
+                )
+                if not all_have_results:
+                    # Skip this assistant+tool_calls block — results are missing
+                    # (stale conversation history). Include as plain text instead.
+                    if content.content:
+                        messages.append({
+                            "role": "assistant",
+                            "content": str(content.content),
+                        })
+                    continue
+
                 # Assistant message with tool calls — no text content
                 msg: dict[str, Any] = {
                     "role": "assistant",
@@ -171,18 +185,17 @@ def _convert_chat_log_to_messages(
 
                 # Immediately append matching tool results in order
                 for tc in content.tool_calls:
-                    result = tool_results.get(tc.id)
-                    if result:
-                        messages.append({
-                            "role": "tool",
-                            "tool_call_id": _to_mistral_id(str(result.tool_call_id)),
-                            "name": str(result.tool_name),
-                            "content": json.dumps(
-                                _sanitize(result.tool_result)
-                                if isinstance(result.tool_result, (dict, list))
-                                else result.tool_result
-                            ),
-                        })
+                    result = tool_results[tc.id]
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": _to_mistral_id(str(result.tool_call_id)),
+                        "name": str(result.tool_name),
+                        "content": json.dumps(
+                            _sanitize(result.tool_result)
+                            if isinstance(result.tool_result, (dict, list))
+                            else result.tool_result
+                        ),
+                    })
             else:
                 # Regular assistant message (no tool calls)
                 messages.append({
@@ -377,12 +390,6 @@ class MistralConversationEntity(ConversationEntity):
         # --- Standard path: chat completions with tool-call loop ---------
         for _iteration in range(MAX_TOOL_ITERATIONS):
             messages = _convert_chat_log_to_messages(chat_log)
-
-            _LOGGER.warning(
-                "Mistral request iteration=%d, messages=%s",
-                _iteration,
-                json.dumps([{"role": m["role"], "has_tool_calls": "tool_calls" in m, "tool_call_id": m.get("tool_call_id")} for m in messages], default=str),
-            )
 
             # Build payload — _sanitize ensures ALL keys are strings
             payload: dict[str, Any] = _sanitize({

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -378,6 +378,12 @@ class MistralConversationEntity(ConversationEntity):
         for _iteration in range(MAX_TOOL_ITERATIONS):
             messages = _convert_chat_log_to_messages(chat_log)
 
+            _LOGGER.warning(
+                "Mistral request iteration=%d, messages=%s",
+                _iteration,
+                json.dumps([{"role": m["role"], "has_tool_calls": "tool_calls" in m, "tool_call_id": m.get("tool_call_id")} for m in messages], default=str),
+            )
+
             # Build payload — _sanitize ensures ALL keys are strings
             payload: dict[str, Any] = _sanitize({
                 "model": model,

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -110,6 +110,17 @@ def _format_tool(tool: llm.Tool, custom_serializer: Any = None) -> dict[str, Any
     }
 
 
+def _to_mistral_id(ha_id: str) -> str:
+    """Convert an HA tool_call ID to a Mistral-compatible 9-char alphanumeric ID.
+
+    Mistral requires tool_call IDs to be exactly 9 characters, a-z A-Z 0-9.
+    HA's chat_log uses 26-char ULIDs. We hash deterministically so the same
+    HA ID always maps to the same Mistral ID.
+    """
+    import hashlib
+    return hashlib.md5(ha_id.encode()).hexdigest()[:9]
+
+
 def _convert_chat_log_to_messages(
     chat_log: conversation.ChatLog,
 ) -> list[dict[str, Any]]:
@@ -132,7 +143,7 @@ def _convert_chat_log_to_messages(
             if content.tool_calls:
                 msg["tool_calls"] = [
                     {
-                        "id": str(tc.id),
+                        "id": _to_mistral_id(str(tc.id)),
                         "type": "function",
                         "function": {
                             "name": str(tc.tool_name),
@@ -151,7 +162,7 @@ def _convert_chat_log_to_messages(
         elif isinstance(content, conversation.ToolResultContent):
             messages.append({
                 "role": "tool",
-                "tool_call_id": str(content.tool_call_id),
+                "tool_call_id": _to_mistral_id(str(content.tool_call_id)),
                 "name": str(content.tool_name),
                 "content": json.dumps(
                     _sanitize(content.tool_result)

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -126,9 +126,19 @@ def _convert_chat_log_to_messages(
 ) -> list[dict[str, Any]]:
     """Convert HA ChatLog content into Mistral chat completions messages.
 
-    All values are passed through _sanitize() to guarantee string dict keys.
+    Mistral requires:
+    - Each assistant message with tool_calls must be followed by exactly
+      one tool result per tool_call, in order.
+    - An assistant message with tool_calls should not have text content.
     """
     messages: list[dict[str, Any]] = []
+
+    # Collect tool results indexed by tool_call_id for pairing
+    tool_results: dict[str, conversation.ToolResultContent] = {}
+    for content in chat_log.content:
+        if isinstance(content, conversation.ToolResultContent):
+            tool_results[content.tool_call_id] = content
+
     for content in chat_log.content:
         if isinstance(content, conversation.SystemContent):
             messages.append({"role": "system", "content": str(content.content)})
@@ -137,39 +147,51 @@ def _convert_chat_log_to_messages(
             messages.append({"role": "user", "content": str(content.content)})
 
         elif isinstance(content, conversation.AssistantContent):
-            msg: dict[str, Any] = {"role": "assistant"}
-            if content.content:
-                msg["content"] = str(content.content)
             if content.tool_calls:
-                msg["tool_calls"] = [
-                    {
-                        "id": _to_mistral_id(str(tc.id)),
-                        "type": "function",
-                        "function": {
-                            "name": str(tc.tool_name),
-                            "arguments": json.dumps(
-                                _sanitize(tc.tool_args) if isinstance(tc.tool_args, dict)
-                                else tc.tool_args
-                            ),
-                        },
-                    }
-                    for tc in content.tool_calls
-                ]
-            if "content" not in msg and "tool_calls" not in msg:
-                msg["content"] = ""
-            messages.append(msg)
+                # Assistant message with tool calls — no text content
+                msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": _to_mistral_id(str(tc.id)),
+                            "type": "function",
+                            "function": {
+                                "name": str(tc.tool_name),
+                                "arguments": json.dumps(
+                                    _sanitize(tc.tool_args) if isinstance(tc.tool_args, dict)
+                                    else tc.tool_args
+                                ),
+                            },
+                        }
+                        for tc in content.tool_calls
+                    ],
+                }
+                messages.append(msg)
 
-        elif isinstance(content, conversation.ToolResultContent):
-            messages.append({
-                "role": "tool",
-                "tool_call_id": _to_mistral_id(str(content.tool_call_id)),
-                "name": str(content.tool_name),
-                "content": json.dumps(
-                    _sanitize(content.tool_result)
-                    if isinstance(content.tool_result, (dict, list))
-                    else content.tool_result
-                ),
-            })
+                # Immediately append matching tool results in order
+                for tc in content.tool_calls:
+                    result = tool_results.get(tc.id)
+                    if result:
+                        messages.append({
+                            "role": "tool",
+                            "tool_call_id": _to_mistral_id(str(result.tool_call_id)),
+                            "name": str(result.tool_name),
+                            "content": json.dumps(
+                                _sanitize(result.tool_result)
+                                if isinstance(result.tool_result, (dict, list))
+                                else result.tool_result
+                            ),
+                        })
+            else:
+                # Regular assistant message (no tool calls)
+                messages.append({
+                    "role": "assistant",
+                    "content": str(content.content or ""),
+                })
+
+        # ToolResultContent is handled above paired with tool_calls
+        # Skip standalone tool results to avoid duplicates
 
     return messages
 


### PR DESCRIPTION
After testing, I have optimized the repeat calls. (changing topic, follow-up questions) more. 

- Tool call IDs shortened to 9 chars
- Tool results paired correctly with tool calls
- Orphaned tool calls stripped from history

Should be final PR for now :-) 