### PR TITLE
Update available TTS voices and set new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ A: Make sure you performed a full restart (not just reload) and cleared any `__p
 A: Check the HA logs for the full error body. A common cause is an invalid model name or a temperature value outside 0.0–1.0.
 
 **Q: Can I use TTS with this integration?**
-A: Mistral has no TTS API. Use Piper (local, free), Google TTS, or ElevenLabs as your TTS provider in the voice assistant pipeline.
+A: Now that Mistral has a TTS model, yes. Please refer to Text-to-speech (TTS) section for details.
 
 **Q: How much does it cost?**
 A: With `ministral-8b-latest` and typical home use, expect less than €1–2 per month. Voxtral STT adds ~€0.003/minute. See [mistral.ai/pricing](https://mistral.ai/pricing/).

--- a/custom_components/mistral_conversation/const.py
+++ b/custom_components/mistral_conversation/const.py
@@ -24,7 +24,7 @@ DEFAULT_TEMPERATURE = 0.7          # Mistral range: 0.0–1.0
 DEFAULT_CONTINUE_CONVERSATION = False
 DEFAULT_WEB_SEARCH = False
 DEFAULT_STT_LANGUAGE = ""          # empty = Voxtral auto-detect
-DEFAULT_TTS_VOICE = "neutral_female"
+DEFAULT_TTS_VOICE = "en_paul_neutral"
 
 DEFAULT_PROMPT = (
     "You are a helpful voice assistant for a smart home called {{ ha_name }}.\n"
@@ -65,26 +65,35 @@ TTS_MODEL = "voxtral-mini-tts-2603"
 
 # Available voices per Mistral TTS documentation (voxtral-mini-tts-2603)
 TTS_VOICES = [
-    "casual_female",    # English – Female
-    "casual_male",      # English – Male
-    "cheerful_female",  # English – Female
-    "neutral_female",   # English – Female (default)
-    "neutral_male",     # English – Male
-    "fr_female",        # French – Female
-    "fr_male",          # French – Male
-    "es_female",        # Spanish – Female
-    "es_male",          # Spanish – Male
-    "de_female",        # German – Female
-    "de_male",          # German – Male
-    "it_female",        # Italian – Female
-    "it_male",          # Italian – Male
-    "pt_female",        # Portuguese – Female
-    "pt_male",          # Portuguese – Male
-    "nl_female",        # Dutch – Female
-    "nl_male",          # Dutch – Male
-    "ar_male",          # Arabic – Male
-    "hi_female",        # Hindi – Female
-    "hi_male",          # Hindi – Male
+    "en_paul_angry",
+    "en_paul_cheerful",
+    "en_paul_confident",
+    "en_paul_excited",
+    "en_paul_frustrated",
+    "en_paul_happy",
+    "en_paul_neutral",
+    "en_paul_sad",
+    "fr_marie_angry",
+    "fr_marie_curious",
+    "fr_marie_excited",
+    "fr_marie_happy",
+    "fr_marie_neutral",
+    "fr_marie_sad",
+    "gb_jane_confused",
+    "gb_jane_curious",
+    "gb_jane_frustrated",
+    "gb_jane_jealousy",
+    "gb_jane_neutral",
+    "gb_jane_sad",
+    "gb_jane_sarcasm",
+    "gb_jane_shameful",
+    "gb_oliver_angry",
+    "gb_oliver_cheerful",
+    "gb_oliver_confident",
+    "gb_oliver_curious",
+    "gb_oliver_excited",
+    "gb_oliver_neutral",
+    "gb_oliver_sad"
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix voices not found error in TTS requests.

List of available voices was retrieved this way:

`curl https://api.mistral.ai/v1/audio/voices?limit=100  -X GET  -H 'Authorization: Bearer APIKEY' -s | jq -r '.items[].slug'`

Adapted from https://docs.mistral.ai/api/endpoint/audio/voices#operation-list_voices_v1_audio_voices_get 

Default is proposed to `en_paul_neutral`, voices seem currently only available for english, french, and great britain english.