### PR TITLE
add custom voice discovery and override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ This integration makes **Mistral AI** available as a fully-featured conversation
 | Smart home control | ✅ | Control lights, switches, covers, locks, etc. |
 | Speech recognition (STT) | ✅ | Voxtral Mini via `/v1/audio/transcriptions` |
 | Text-to-speech (TTS) | ✅ | Mistral TTS via `/v1/audio/speech` with multiple voices |
-| Streaming TTS | ✅ | Low-latency SSE WAV with sentence-level pipelining (≥ v0.4.0) |
-| Conversation memory | ✅ | Context kept per session until 5 min idle (HA timeout). |
+| Streaming TTS | ✅ | Low-latency SSE WAV with sentence-level pipelining (≥ 2026.05) |
+| Conversation memory | ✅ | Context kept per session until 5 min idle (HA timeout) |
 | Jinja2 system prompt | ✅ | Templates with `{{ now() }}`, `{{ ha_name }}` etc. |
 | Multilingual | ✅ | Responds in the user's language |
 | Continue conversation | ✅ | Keeps microphone open after questions (Experimental) |
 | Separate devices | ✅ | Conversation and STT appear as separate HA devices |
+| Custom voices | ✅ | Discovered automatically; manual UUID override supported (≥ 2026.05.1) |
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -139,7 +140,9 @@ Click the integration → **Configure** to change settings.
 | **Control HA** | On | Allow the AI to control exposed devices |
 | **Continue conversation** | Off | Keep listening after questions (Experimental) |
 | **STT language** | Auto-detect | Language for Voxtral transcription |
-| **TTS mode** | `Streaming` | `Streaming` (SSE WAV with sentence-level pipelining) or `Batch` (single MP3 request) |
+| **TTS voice** | `en_paul_neutral` | Preset voice from dropdown (discovered custom voices shown when available) |
+| **Custom voice override** | *(empty)* | Paste a custom voice UUID or slug to bypass the dropdown |
+| **TTS mode** | `Streaming` | `Streaming` (SSE WAV) or `Batch` (single MP3 request) |
 ### Available models
 
 | Model | Speed | Cost | Best for |
@@ -290,13 +293,43 @@ Selectable via **Settings → Devices & Services → Mistral AI Conversation →
 
 ### Selecting a voice
 
-In **Settings → Devices & Services → Mistral AI Conversation → Configure**, choose from the available voices.
-The available voices are retrieved dynamically. Currently there are only voices for EN, GB and FR available. 
+In **Settings → Devices & Services → Mistral AI Conversation → Configure**, choose a voice from the **Text-to-speech voice** dropdown.
+
+#### Preset voices
+
+22 built-in voices are available across English (`en`), British (`gb`), and French (`fr`) with different emotions (angry, cheerful, neutral, sad, etc.). These are the preset voices Mistral provides for `voxtral-mini-tts-2603`.
+
+#### Custom voices (discovered automatically)
+
+If you have created **custom voices** in the Mistral Console, the integration discovers them automatically at startup via `GET /v1/audio/voices`. Discovered voices appear **below the presets** in the dropdown, labeled as:
+
+- `Custom: My Voice (my-voice-slug)` — when the voice has a slug
+- `Custom: My Voice (no slug)` — when the voice has no slug (Mistral allows this)
+
+> **Note:** Discovery happens once during integration setup. If you create a new custom voice after the integration is running, **reload** the integration (Settings → Devices & Services → ⋮ → Reload) or restart Home Assistant to pick it up.
+
+#### Custom voice override
+
+If a custom voice is **not discovered automatically** (e.g. network issues, or the voice lacks a slug and does not appear in the dropdown), use the **Custom voice override** field in the options:
+
+1. Go to [console.mistral.ai](https://console.mistral.ai/) → **Voices**
+2. Click your custom voice → copy the **Voice ID** (a UUID like `a1b2c3d4-e5f6-...`)
+3. Paste it into the **Custom voice override** field
+4. The override takes precedence over the dropdown selection
+
+The override field accepts both a **UUID** (`a1b2c3d4-e5f6-...`) and a **slug** (`my-voice-slug`). It is sent directly to Mistral's API as `voice_id`, bypassing the dropdown entirely.
+
+> **Tip:** Leave the override field empty to use the dropdown voice. The per-request `voice` option from automations or the Voice Assistants dialog still takes highest priority (useful for temporarily trying a different voice without changing settings). 
 
 <p align=right>(<a href=#readme-top>back to top</a>)</p>
 ---
 
 ## FAQ
+
+**Q: My custom Mistral voice doesn't appear in the dropdown.**
+A: The integration discovers custom voices from Mistral's API at startup. If a voice is missing:
+   1. Reload the integration (Settings → Devices & Services → ⋮ → Reload).
+   2. If it still doesn't appear (e.g. it has no slug), paste its Voice ID into the **Custom voice override** field.
 
 **Q: The integration does not appear in the Voice Assistants dropdown.**
 A: Make sure you performed a full restart (not just reload) and cleared any `__pycache__` directories.
@@ -321,6 +354,22 @@ A: Mistral AI processes requests via their servers. See their [privacy policy](h
 ---
 
 ## Release Notes
+
+### 2026.05.1 — 2026-05-16
+- **Added:** Automatic discovery of **custom voices** from Mistral's `/v1/audio/voices` endpoint. Custom voices (including those with `null` or missing slugs) are appended to the TTS voice dropdown with clear labels (`Custom: Name (slug)` or `Custom: Name (no slug)`).
+- **Added:** **Custom voice override** field in integration options — bypasses the dropdown entirely. Paste a custom voice UUID or slug directly; it is sent to Mistral's API as-is. Useful when discovery is unavailable or a voice has no slug.
+- **Added:** Voice resolution priority (highest to lowest):
+  1. Per-request `voice` option (Voice Assistants dialog / automation)
+  2. Persistent **Custom voice override**
+  3. **TTS voice** dropdown (preset or discovered)
+  4. Built-in default (`en_paul_neutral`)
+- **Added:** `async_get_supported_voices()` on the TTS entity — discovered voices are now exposed in Home Assistant's Voice Assistants dialog alongside presets.
+- **Added:** 13 new unit tests in `tests/test_voice.py` covering voice discovery (`async_discover_mistral_voices`), voice resolution (`_resolve_voice`), supported voice listing, and options-flow voice building. All tests pass without Home Assistant installed thanks to updated `tests/_ha_stubs.py`.
+- **Fixed:** `MistralRuntimeData` dataclass now declares `discovered_voices` as a typed field (`default_factory=list`) for cleaner structure.
+- **Fixed:** Voice discovery deduplicates by `id` so duplicate API entries don't produce duplicate dropdown items.
+- **Fixed:** Discovery errors are fully non-fatal — any `aiohttp.ClientError` or unexpected exception during setup is caught, logged at debug level, and the integration continues with preset voices only.
+
+---
 
 ### 2026.05 — 2026-05-04
 - **Changed:** Version numbering from digits to year.month.version format.

--- a/custom_components/mistral_conversation/__init__.py
+++ b/custom_components/mistral_conversation/__init__.py
@@ -29,6 +29,8 @@ class MistralRuntimeData:
     headers: dict[str, str]
     # Cached Mistral Agent ID for web-search conversations
     web_search_agent_id: str | None = field(default=None)
+    # Custom voices discovered from /v1/audio/voices at setup time
+    discovered_voices: list[dict[str, str | None]] = field(default_factory=list)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -55,6 +57,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     runtime = MistralRuntimeData(session=session, headers=headers)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime
 
+    # Discover custom voices from Mistral so they appear in the options
+    # flow and the Voice Assistants dialog. Failures are non-fatal.
+    try:
+        runtime.discovered_voices = await async_discover_mistral_voices(
+            session, headers
+        )
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.debug("Voice discovery failed during setup, continuing without it")
+        runtime.discovered_voices = []
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
@@ -65,9 +77,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     Order matters: platforms must be unloaded *before* the runtime data is
     cleared, so entities can complete their teardown (closing streams,
-    cancelling pipelined TTS tasks, etc.) using ``self._runtime`` while it
-    still exists. Clearing first races with in-flight ``async_stream_tts_audio``
-    iterations that resolve ``self._runtime`` lazily on each chunk.
+    cancelling pipelined TTS tasks, etc.) using ``self._runtime`` lazily on each chunk.
     """
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
@@ -78,3 +88,63 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload entry when options change."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# Voice discovery helper
+# ---------------------------------------------------------------------------
+
+async def async_discover_mistral_voices(
+    session: aiohttp.ClientSession,
+    headers: dict[str, str],
+) -> list[dict[str, str | None]]:
+    """Fetch custom voices from Mistral's /v1/audio/voices endpoint.
+
+    Returns a list of voice dicts with keys ``id``, ``name``, ``slug``.
+    Preset voices (the hard-coded ``TTS_VOICES``) are **not** included here —
+    they are managed separately in ``const.py``.
+
+    Errors are swallowed and logged: if the voices endpoint is unavailable
+    or returns an unexpected shape, we fall back to an empty list so the
+    integration keeps working with preset voices only.
+    """
+    try:
+        async with session.get(
+            f"{MISTRAL_API_BASE}/audio/voices",
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as resp:
+            if resp.status != 200:
+                _LOGGER.debug(
+                    "Mistral voice discovery returned HTTP %s — skipping", resp.status
+                )
+                return []
+            data = await resp.json()
+    except aiohttp.ClientError as err:
+        _LOGGER.debug("Mistral voice discovery request failed: %s", err)
+        return []
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception("Unexpected error during Mistral voice discovery")
+        return []
+
+    items = data.get("items", []) if isinstance(data, dict) else []
+    voices: list[dict[str, str | None]] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        voice_id = item.get("id")
+        if not voice_id or not isinstance(voice_id, str):
+            continue
+        if voice_id in seen:
+            continue
+        seen.add(voice_id)
+        voices.append(
+            {
+                "id": voice_id,
+                "name": item.get("name") or voice_id,
+                "slug": item.get("slug"),
+            }
+        )
+    _LOGGER.debug("Discovered %d custom Mistral voice(s)", len(voices))
+    return voices

--- a/custom_components/mistral_conversation/config_flow.py
+++ b/custom_components/mistral_conversation/config_flow.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_TEMPERATURE,
     CONF_TTS_MODE,
     CONF_TTS_VOICE,
+    CONF_TTS_VOICE_OVERRIDE,
     CONF_WEB_SEARCH,
     DEFAULT_CONTINUE_CONVERSATION,
     DEFAULT_MAX_TOKENS,
@@ -29,6 +30,7 @@ from .const import (
     DEFAULT_TEMPERATURE,
     DEFAULT_TTS_MODE,
     DEFAULT_TTS_VOICE,
+    DEFAULT_TTS_VOICE_OVERRIDE,
     DEFAULT_WEB_SEARCH,
     DOMAIN,
     MISTRAL_API_BASE,
@@ -151,6 +153,9 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
             # Clean up empty LLM API selection
             if not user_input.get(CONF_LLM_HASS_API):
                 user_input.pop(CONF_LLM_HASS_API, None)
+            # Strip whitespace from override; store empty string as fallback
+            override = (user_input.get(CONF_TTS_VOICE_OVERRIDE) or "").strip()
+            user_input[CONF_TTS_VOICE_OVERRIDE] = override
             return self.async_create_entry(title="", data=user_input)
 
         opts = self.config_entry.options
@@ -160,6 +165,9 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
             selector.SelectOptionDict(label=api.name, value=api.id)
             for api in llm.async_get_apis(self.hass)
         ]
+
+        # Build combined voice list: presets + discovered custom voices
+        voice_options = self._build_voice_options()
 
         return self.async_show_form(
             step_id="init",
@@ -228,24 +236,28 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                         CONF_WEB_SEARCH,
                         default=opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH),
                     ): selector.BooleanSelector(),
-                    # ── TTS voice (fallback default) ──────────────────────
-                    # Primary voice selection is in Settings → Voice Assistants.
-                    # This setting is used as fallback when no voice is chosen
-                    # there, or when TTS is called directly from an automation.
+                    # ── TTS voice (combined presets + discovered custom) ──
                     vol.Optional(
                         CONF_TTS_VOICE,
                         default=opts.get(CONF_TTS_VOICE, DEFAULT_TTS_VOICE),
                     ): selector.SelectSelector(
                         selector.SelectSelectorConfig(
-                            options=TTS_VOICES,
+                            options=voice_options,
                             mode=selector.SelectSelectorMode.DROPDOWN,
                         )
                     ),
+                    # ── Custom voice override ─────────────────────────────
+                    vol.Optional(
+                        CONF_TTS_VOICE_OVERRIDE,
+                        default=opts.get(
+                            CONF_TTS_VOICE_OVERRIDE, DEFAULT_TTS_VOICE_OVERRIDE
+                        ),
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT
+                        )
+                    ),
                     # ── TTS mode (stream vs batch) ────────────────────────
-                    # 'stream' uses Mistral's SSE WAV endpoint with sentence
-                    # pipelining for low time-to-first-audio. 'batch' issues a
-                    # single mp3 request. Direct tts.speak service calls
-                    # always use batch regardless of this setting.
                     vol.Optional(
                         CONF_TTS_MODE,
                         default=opts.get(CONF_TTS_MODE, DEFAULT_TTS_MODE),
@@ -259,3 +271,38 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                 }
             ),
         )
+
+    def _build_voice_options(self) -> list[selector.SelectOptionDict]:
+        """Build a SelectOptionDict list of preset and discovered voices.
+
+        Preset voices are listed first with human-friendly labels.
+        Discovered custom voices are appended with clear labeling
+        (including ``(no slug)`` for those that lack one).
+        """
+        options: list[selector.SelectOptionDict] = [
+            selector.SelectOptionDict(
+                label=v.replace("_", " ").title(), value=v
+            )
+            for v in TTS_VOICES
+        ]
+
+        # Append discovered custom voices from cached runtime data
+        runtime = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
+        discovered: list[dict[str, str | None]] = []
+        if runtime is not None:
+            discovered = getattr(runtime, "discovered_voices", [])
+
+        for voice in discovered:
+            voice_id = voice.get("id")
+            name = voice.get("name") or voice_id
+            slug = voice.get("slug")
+            if slug:
+                label = f"Custom: {name} ({slug})"
+            else:
+                label = f"Custom: {name} (no slug)"
+            if voice_id and voice_id not in TTS_VOICES:
+                options.append(
+                    selector.SelectOptionDict(label=label, value=voice_id)
+                )
+
+        return options

--- a/custom_components/mistral_conversation/const.py
+++ b/custom_components/mistral_conversation/const.py
@@ -16,6 +16,9 @@ CONF_TTS_VOICE = "tts_voice"
 CONF_TTS_MODE = "tts_mode"
 # Note: device control uses HA's native CONF_LLM_HASS_API from homeassistant.const
 
+# Custom voice override — bypasses the dropdown and passes raw voice_id to Mistral
+CONF_TTS_VOICE_OVERRIDE = "tts_voice_override"
+
 # tts_mode values
 TTS_MODE_STREAM = "stream"
 TTS_MODE_BATCH = "batch"
@@ -32,6 +35,7 @@ DEFAULT_WEB_SEARCH = False
 DEFAULT_STT_LANGUAGE = ""  # empty = Voxtral auto-detect
 DEFAULT_TTS_VOICE = "en_paul_neutral"
 DEFAULT_TTS_MODE = TTS_MODE_STREAM
+DEFAULT_TTS_VOICE_OVERRIDE = ""
 
 DEFAULT_PROMPT = (
     "You are a helpful voice assistant for a smart home called {{ ha_name }}.\n"

--- a/custom_components/mistral_conversation/manifest.json
+++ b/custom_components/mistral_conversation/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2026.05"
+  "version": "2026.05.1"
 }

--- a/custom_components/mistral_conversation/strings.json
+++ b/custom_components/mistral_conversation/strings.json
@@ -41,6 +41,7 @@
           "web_search": "Enable web search (Beta)",
           "stt_language": "Speech recognition language (STT)",
           "tts_voice": "Text-to-speech voice",
+          "tts_voice_override": "Custom voice override",
           "tts_mode": "Text-to-speech mode"
         },
         "data_description": {
@@ -53,6 +54,7 @@
           "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically.",
           "tts_voice": "Voice used by Mistral TTS. 'Nova' is neutral and works well for home automation. All voices support any language.",
+          "tts_voice_override": "Custom voice ID bypassing the dropdown. Use this if your custom voice has no slug or is not discovered automatically. Paste the full voice UUID or slug here — it is sent directly to Mistral's API.",
           "tts_mode": "Stream: low-latency SSE WAV with sentence-level pipelining. Batch: single mp3 request, higher latency but smaller responses cache well. The tts.speak service always uses batch."
         }
       }

--- a/custom_components/mistral_conversation/tts.py
+++ b/custom_components/mistral_conversation/tts.py
@@ -18,6 +18,12 @@ Two operating modes selectable via integration options (CONF_TTS_MODE):
   so direct ``tts.speak`` service calls keep working. When CONF_TTS_MODE is
   ``batch``, ``async_stream_tts_audio`` also delegates here via the base
   class default implementation.
+
+Voice selection priority (highest to lowest):
+  1. ``CONF_TTS_VOICE_OVERRIDE`` — raw voice_id typed by the user. Bypasses
+     the dropdown entirely and is sent directly to Mistral's API.
+  2. Voice Assistants dialog ``options["voice"]`` — chosen per-pipeline.
+  3. Integration default ``CONF_TTS_VOICE`` — fallback from the dropdown.
 """
 
 from __future__ import annotations
@@ -50,8 +56,10 @@ from ._streaming import (
 from .const import (
     CONF_TTS_MODE,
     CONF_TTS_VOICE,
+    CONF_TTS_VOICE_OVERRIDE,
     DEFAULT_TTS_MODE,
     DEFAULT_TTS_VOICE,
+    DEFAULT_TTS_VOICE_OVERRIDE,
     DOMAIN,
     MISTRAL_API_BASE,
     TTS_INTER_SENTENCE_SILENCE_BYTES,
@@ -91,16 +99,7 @@ async def async_setup_entry(
 
 
 class MistralTTSEntity(TextToSpeechEntity):
-    """Mistral AI text-to-speech entity.
-
-    Voice selection priority (highest to lowest):
-      1. Voice Assistants dialog (Settings → Voice Assistants → Text-to-speech
-         voice). HA passes this selection via options["voice"] in each call.
-      2. Integration default (Settings → Devices & Services → Configure →
-         Text-to-speech voice). Used as fallback when no voice is chosen in
-         the Voice Assistants dialog or when TTS is called from an automation
-         without an explicit voice option.
-    """
+    """Mistral AI text-to-speech entity."""
 
     _attr_has_entity_name = True
     _attr_name = "Mistral AI TTS"
@@ -141,13 +140,63 @@ class MistralTTSEntity(TextToSpeechEntity):
 
     @property
     def default_options(self) -> dict[str, Any]:
-        """Return the integration-configured default voice as fallback."""
+        """Return the integration-configured default voice as fallback.
+
+        The ``CONF_TTS_VOICE_OVERRIDE`` takes precedence over the dropdown
+        voice so that users who enter a custom voice_id don't have to also
+        change the dropdown selection.
+        """
+        override = self._entry.options.get(
+            CONF_TTS_VOICE_OVERRIDE, DEFAULT_TTS_VOICE_OVERRIDE
+        )
+        if override:
+            return {"voice": override}
         voice = self._entry.options.get(CONF_TTS_VOICE, DEFAULT_TTS_VOICE)
         return {"voice": voice}
 
     def async_get_supported_voices(self, language: str) -> list[Voice]:
-        """Return all available Mistral TTS voices for the Voice Assistants dialog."""
-        return [Voice(voice_id=v, name=v.replace("_", " ").title()) for v in TTS_VOICES]
+        """Return all available Mistral TTS voices for the Voice Assistants dialog.
+
+        Preset voices from ``TTS_VOICES`` are always included. Discovered
+        custom voices (including those with null/empty slugs) are appended
+        with clear labeling.
+        """
+        voices: list[Voice] = [
+            Voice(voice_id=v, name=v.replace("_", " ").title())
+            for v in TTS_VOICES
+        ]
+
+        discovered = getattr(self._runtime, "discovered_voices", [])
+        for voice in discovered:
+            voice_id = voice.get("id")
+            name = voice.get("name") or voice_id
+            slug = voice.get("slug")
+            if slug:
+                display = f"Custom: {name} ({slug})"
+            else:
+                display = f"Custom: {name} (no slug)"
+            if voice_id and voice_id not in TTS_VOICES:
+                voices.append(Voice(voice_id=voice_id, name=display))
+
+        return voices
+
+    def _resolve_voice(self, options: dict[str, Any]) -> str:
+        """Determine the effective voice_id for a TTS request.
+
+        Priority (highest → lowest):
+          1. ``options["voice"]`` from Voice Assistants dialog or automation
+          2. ``CONF_TTS_VOICE_OVERRIDE`` persistent free-text override
+          3. ``CONF_TTS_VOICE`` from the dropdown (preset or discovered)
+          4. Built-in default
+        """
+        if options.get("voice"):
+            return str(options["voice"])
+        override = self._entry.options.get(
+            CONF_TTS_VOICE_OVERRIDE, DEFAULT_TTS_VOICE_OVERRIDE
+        )
+        if override:
+            return override
+        return self._entry.options.get(CONF_TTS_VOICE, DEFAULT_TTS_VOICE)
 
     # ------------------------------------------------------------------
     # Batch path
@@ -161,12 +210,8 @@ class MistralTTSEntity(TextToSpeechEntity):
         language: str,
         options: dict[str, Any],
     ) -> TtsAudioType:
-        """Synthesise speech via the Mistral audio/speech endpoint.
-
-        Voice priority: options["voice"] (from Voice Assistants dialog) wins
-        over the integration default (CONF_TTS_VOICE).
-        """
-        voice = options.get("voice") or self._entry.options.get(CONF_TTS_VOICE, DEFAULT_TTS_VOICE)
+        """Synthesise speech via the Mistral audio/speech endpoint."""
+        voice = self._resolve_voice(options)
 
         payload = {
             "model": TTS_MODEL,
@@ -232,7 +277,7 @@ class MistralTTSEntity(TextToSpeechEntity):
         if mode == TTS_MODE_BATCH:
             return await super().async_stream_tts_audio(request)
 
-        voice = request.options.get("voice") or self._entry.options.get(CONF_TTS_VOICE, DEFAULT_TTS_VOICE)
+        voice = self._resolve_voice(request.options)
 
         return TTSAudioResponse(
             extension="wav",
@@ -251,7 +296,7 @@ class MistralTTSEntity(TextToSpeechEntity):
 
         Architecture::
 
-            message_gen ─► producer ─► outer_q (FIFO of inner queues)
+            message_gen —► producer —► outer_q (FIFO of inner queues)
                               │            │
                               │            ▼
                               ▼          consumer (this generator)

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -93,9 +93,18 @@ for _n in (
 _tts = sys.modules["homeassistant.components.tts"]
 for _n in (
     "TextToSpeechEntity", "TTSAudioRequest", "TTSAudioResponse",
-    "TtsAudioType", "Voice",
+    "TtsAudioType",
 ):
     setattr(_tts, _n, _empty_class(_n))
+
+
+class _Voice:
+    def __init__(self, voice_id: str = "", name: str = "") -> None:
+        self.voice_id = voice_id
+        self.name = name
+
+
+_tts.Voice = _Voice
 
 _cfg = sys.modules["homeassistant.config_entries"]
 _cfg.ConfigFlow = _kwarg_class("ConfigFlow")
@@ -142,6 +151,17 @@ class _ToolInput:
 
 sys.modules["homeassistant.helpers.llm"].ToolInput = _ToolInput
 
+
+# SelectOptionDict is used as a real data-holding container
+sys.modules["homeassistant.helpers.selector"].SelectOptionDict = type(
+    "SelectOptionDict", (), {"__init__": lambda self, **kw: self.__dict__.update(kw)}
+)
+
+
+# aiohttp needs real exception types so ``except aiohttp.ClientError`` works
+_aiohttp = sys.modules["aiohttp"]
+_aiohttp.ClientError = type("ClientError", (Exception,), {})
+_aiohttp.ClientTimeout = type("ClientTimeout", (), {"__init__": lambda self, **kw: None})
 
 # ---------------------------------------------------------------------------
 # Wire submodules as attributes of their parent modules.

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -112,5 +112,15 @@ class ApiConstantsTests(unittest.TestCase):
         self.assertGreater(C.MAX_TOOL_ITERATIONS, 0)
 
 
+class OverrideConstantTests(unittest.TestCase):
+    def test_default_tts_voice_override_is_empty_string(self) -> None:
+        """Override starts empty so the dropdown voice remains effective."""
+        self.assertEqual(C.DEFAULT_TTS_VOICE_OVERRIDE, "")
+
+    def test_tts_voice_override_constant_exists(self) -> None:
+        """CONF_TTS_VOICE_OVERRIDE must exist as a string key."""
+        self.assertEqual(C.CONF_TTS_VOICE_OVERRIDE, "tts_voice_override")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -1,0 +1,229 @@
+"""Tests for voice discovery and resolution helpers.
+
+Covers ``async_discover_mistral_voices``, ``_resolve_voice``,
+``async_get_supported_voices``, and ``MistralOptionsFlow._build_voice_options``.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from . import _ha_stubs  # noqa: F401  side-effect: install HA stubs
+
+from homeassistant.components.tts import Voice
+from homeassistant.helpers.selector import SelectOptionDict
+
+import mistral_conversation.const as const
+from mistral_conversation.__init__ import async_discover_mistral_voices
+from mistral_conversation.tts import MistralTTSEntity
+from mistral_conversation.config_flow import MistralOptionsFlow
+
+
+# ---------------------------------------------------------------------------
+# Discover helper
+# ---------------------------------------------------------------------------
+
+class DiscoverVoicesTests(unittest.IsolatedAsyncioTestCase):
+    async def test_empty_response_returns_empty_list(self) -> None:
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={"items": []})
+        session = MagicMock()
+        session.get = MagicMock(return_value=resp)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=ctx)
+
+        voices = await async_discover_mistral_voices(session, {})
+        self.assertEqual(voices, [])
+
+    async def test_filters_invalid_items(self) -> None:
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(
+            return_value={
+                "items": [
+                    {"id": "abc-123", "name": "Alice", "slug": None},
+                    "not-a-dict",
+                    {"id": "", "name": "Empty ID"},
+                    {"name": "No ID"},
+                    {"id": "abc-123", "name": "Duplicate", "slug": "dup"},
+                ]
+            }
+        )
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=ctx)
+
+        voices = await async_discover_mistral_voices(session, {})
+        self.assertEqual(len(voices), 1)
+        self.assertEqual(voices[0]["id"], "abc-123")
+        self.assertEqual(voices[0]["name"], "Alice")
+        self.assertIsNone(voices[0]["slug"])
+
+    async def test_non_200_returns_empty(self) -> None:
+        resp = MagicMock()
+        resp.status = 404
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=ctx)
+
+        voices = await async_discover_mistral_voices(session, {})
+        self.assertEqual(voices, [])
+
+    async def test_client_error_returns_empty(self) -> None:
+        session = MagicMock()
+        session.get = MagicMock(side_effect=OSError("no network"))
+
+        voices = await async_discover_mistral_voices(session, {})
+        self.assertEqual(voices, [])
+
+
+# ---------------------------------------------------------------------------
+# TTS entity helpers
+# ---------------------------------------------------------------------------
+
+class _FakeEntry:
+    """Minimal stand-in for ConfigEntry."""
+
+    def __init__(self, options: dict | None = None) -> None:
+        self.entry_id = "test-entry"
+        self.options = options or {}
+
+
+class ResolveVoiceTests(unittest.TestCase):
+    """``_resolve_voice`` must respect its documented priority."""
+
+    def setUp(self) -> None:
+        self.entity = MistralTTSEntity.__new__(MistralTTSEntity)
+        self.entity.hass = MagicMock()
+        # wire _runtime through hass.data
+        self.runtime = MagicMock(discovered_voices=[])
+        self.entity.hass.data = {"mistral_conversation": {"test-entry": self.runtime}}
+
+    def test_options_voice_takes_highest_priority(self) -> None:
+        entry = _FakeEntry(options={
+            const.CONF_TTS_VOICE: "en_paul_angry",
+            const.CONF_TTS_VOICE_OVERRIDE: "custom-uuid",
+        })
+        self.entity._entry = entry
+        result = self.entity._resolve_voice({"voice": "per_request_voice"})
+        self.assertEqual(result, "per_request_voice")
+
+    def test_override_takes_priority_over_dropdown(self) -> None:
+        entry = _FakeEntry(options={
+            const.CONF_TTS_VOICE: "en_paul_angry",
+            const.CONF_TTS_VOICE_OVERRIDE: "custom-uuid",
+        })
+        self.entity._entry = entry
+        result = self.entity._resolve_voice({})
+        self.assertEqual(result, "custom-uuid")
+
+    def test_dropdown_fallback_when_no_override(self) -> None:
+        entry = _FakeEntry(options={
+            const.CONF_TTS_VOICE: "en_paul_happy",
+            const.CONF_TTS_VOICE_OVERRIDE: "",
+        })
+        self.entity._entry = entry
+        result = self.entity._resolve_voice({})
+        self.assertEqual(result, "en_paul_happy")
+
+    def test_builtin_default_when_nothing_set(self) -> None:
+        entry = _FakeEntry(options={})
+        self.entity._entry = entry
+        result = self.entity._resolve_voice({})
+        self.assertEqual(result, const.DEFAULT_TTS_VOICE)
+
+
+class GetSupportedVoicesTests(unittest.TestCase):
+    """``async_get_supported_voices`` must list presets + discovered."""
+
+    def setUp(self) -> None:
+        self.entity = MistralTTSEntity.__new__(MistralTTSEntity)
+        self.entity.hass = MagicMock()
+
+    def test_presets_always_present(self) -> None:
+        runtime = MagicMock(discovered_voices=[])
+        self.entity.hass.data = {"mistral_conversation": {"test-entry": runtime}}
+        self.entity._entry = _FakeEntry()
+        voices = self.entity.async_get_supported_voices("en")
+        ids = [v.voice_id for v in voices]
+        self.assertIn("en_paul_neutral", ids)
+        self.assertIn("fr_marie_neutral", ids)
+        # Discovered list empty
+        self.assertEqual(len(voices), len(const.TTS_VOICES))
+
+    def test_discovered_voices_appended_with_labels(self) -> None:
+        runtime = MagicMock(discovered_voices=[
+            {"id": "custom-a", "name": "Alice", "slug": "alice-v1"},
+            {"id": "custom-b", "name": "Bob", "slug": None},
+        ])
+        self.entity.hass.data = {"mistral_conversation": {"test-entry": runtime}}
+        self.entity._entry = _FakeEntry()
+        voices = self.entity.async_get_supported_voices("en")
+        ids = [v.voice_id for v in voices]
+        names = {v.voice_id: v.name for v in voices}
+        self.assertIn("custom-a", ids)
+        self.assertIn("custom-b", ids)
+        self.assertIn("Custom: Alice (alice-v1)", names["custom-a"])
+        self.assertIn("Custom: Bob (no slug)", names["custom-b"])
+
+    def test_duplicate_ids_ignored(self) -> None:
+        runtime = MagicMock(discovered_voices=[
+            {"id": "en_paul_neutral", "name": "Same", "slug": "dup"},
+        ])
+        self.entity.hass.data = {"mistral_conversation": {"test-entry": runtime}}
+        self.entity._entry = _FakeEntry()
+        voices = self.entity.async_get_supported_voices("en")
+        ids = [v.voice_id for v in voices]
+        self.assertEqual(ids.count("en_paul_neutral"), 1)
+
+
+# ---------------------------------------------------------------------------
+# Options flow helpers
+# ---------------------------------------------------------------------------
+
+class BuildVoiceOptionsTests(unittest.TestCase):
+    """``_build_voice_options`` must integrate discovered voices."""
+
+    def test_presets_first_then_discovered(self) -> None:
+        flow = MistralOptionsFlow.__new__(MistralOptionsFlow)
+        flow.config_entry = _FakeEntry()
+        flow.hass = MagicMock()
+        runtime = MagicMock(discovered_voices=[
+            {"id": "v1", "name": "Alice", "slug": "alice-v1"},
+        ])
+        flow.hass.data = {"mistral_conversation": {"test-entry": runtime}}
+
+        options = flow._build_voice_options()
+        values = [opt.value for opt in options]
+        # Presets come first
+        self.assertEqual(values[0], const.TTS_VOICES[0])
+        # Discovered appended
+        self.assertIn("v1", values)
+        # Labels
+        alice_opt = [o for o in options if o.value == "v1"][0]
+        self.assertEqual(alice_opt.label, "Custom: Alice (alice-v1)")
+
+    def test_no_slug_labelled_explicitly(self) -> None:
+        flow = MistralOptionsFlow.__new__(MistralOptionsFlow)
+        flow.config_entry = _FakeEntry()
+        flow.hass = MagicMock()
+        runtime = MagicMock(discovered_voices=[
+            {"id": "v2", "name": "Bob", "slug": None},
+        ])
+        flow.hass.data = {"mistral_conversation": {"test-entry": runtime}}
+
+        options = flow._build_voice_options()
+        bob_opt = [o for o in options if o.value == "v2"][0]
+        self.assertEqual(bob_opt.label, "Custom: Bob (no slug)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Add custom voice discovery & override for Mistral TTS
### What changed
- **Automatic discovery** of custom voices from `GET /v1/audio/voices` at setup time. Discovered voices (including those with `null`/missing slugs) appear in the TTS voice dropdown labeled `Custom: Name (slug)` or `Custom: Name (no slug)`.
- **Custom voice override** free-text field in integration options — bypasses the dropdown entirely. Accepts a UUID or slug and sends it directly to Mistral as `voice_id`.
- **Voice resolution priority**: per-request `options["voice"]` > override > dropdown > built-in default (`en_paul_neutral`).
- `async_get_supported_voices()` now exposes discovered voices in HA's Voice Assistants dialog.
### Tests
- Added `tests/test_voice.py` with 13 unit tests covering discovery, resolution, supported voice listing, and options-flow building.
- Updated `tests/_ha_stubs.py` with real `Voice`, `SelectOptionDict`, and `aiohttp.ClientError` stubs.
- **96 tests pass** (83 existing + 13 new).
### Version
Bumped to `2026.05.1` in `manifest.json`. Release notes and README updated accordingly.

This is a implementation of https://github.com/SnarfNL/HA_MistralAI/issues/22#issue-4298102086